### PR TITLE
chore: Disable lint on useEffect in 3 spots where it is unnecessary/wrong

### DIFF
--- a/frontend/src/components/Answer/Answer.tsx
+++ b/frontend/src/components/Answer/Answer.tsx
@@ -72,6 +72,7 @@ export const Answer = ({ answer, onCitationClicked, onExectResultClicked }: Prop
       currentFeedbackState = initializeAnswerFeedback(answer);
     }
     setFeedbackState(currentFeedbackState);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appStateContext?.state.feedbackState, feedbackState, answer.message_id]);
 
   const createCitationFilepath = (citation: Citation, index: number, truncate: boolean = false) => {

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -105,6 +105,7 @@ export const Chat = () => {
       });
       toggleErrorDialog();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     appStateContext?.state.isCosmosDBAvailable,
     isCosmosDbConfigured,
@@ -764,6 +765,7 @@ export const Chat = () => {
 
   useEffect(() => {
     if (AUTH_ENABLED !== undefined) getUserInfoList();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [AUTH_ENABLED]);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
### Motivation and Context

Currently, PRs are including the following lint warnings:

```
* Check warning on line 75 in frontend/src/components/Answer/Answer.tsx
  React Hook useEffect has a missing dependency: 'answer'. Either include it or remove the dependency array

* Check warning on line 108 in frontend/src/pages/chat/Chat.tsx
  React Hook useEffect has a missing dependency: 'toggleErrorDialog'. Either include it or remove the dependency array

* Check warning on line 767 in frontend/src/pages/chat/Chat.tsx
  React Hook useEffect has a missing dependency: 'getUserInfoList'. Either include it or remove the dependency array  
```
These warnings seem noisy and unhelpful. This PR tells ESLint to ignore those warnings.