### PR TITLE
AlertBanner updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,6 +103,8 @@ frontend_settings = {
         "show_chat_history_button": app_settings.ui.show_chat_history_button,
         "alert_banner_message": app_settings.ui.alert_banner_message,
         "alert_banner_type": app_settings.ui.alert_banner_type,
+        "alert_banner_dismissible": app_settings.ui.alert_banner_dismissible,
+        "alert_banner_id": app_settings.ui.alert_banner_id,
         "coach_mark_expiration_date_iso": app_settings.ui.coach_mark_expiration_date_iso
     },
     "sanitize_answer": app_settings.base_settings.sanitize_answer,

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -51,6 +51,7 @@ class _UiSettings(BaseSettings):
     show_chat_history_button: bool = True
     alert_banner_message: Optional[str] = None
     alert_banner_type: str = "info"
+    alert_banner_dismissible: bool = False
     coach_mark_expiration_date_iso: Optional[str] = None
 
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -52,6 +52,7 @@ class _UiSettings(BaseSettings):
     alert_banner_message: Optional[str] = None
     alert_banner_type: str = "info"
     alert_banner_dismissible: bool = False
+    alert_banner_id: Optional[str] = None
     coach_mark_expiration_date_iso: Optional[str] = None
 
 

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -144,6 +144,7 @@ export type UI = {
   alert_banner_message?: string;
   alert_banner_type?: string;
   alert_banner_dismissible?: boolean;
+  alert_banner_id?: string;
   coach_mark_expiration_date_iso?: string;
 };
 

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -143,6 +143,7 @@ export type UI = {
   show_chat_history_button?: boolean;
   alert_banner_message?: string;
   alert_banner_type?: string;
+  alert_banner_dismissible?: boolean;
   coach_mark_expiration_date_iso?: string;
 };
 

--- a/frontend/src/components/AlertBanner/AlertBanner.module.css
+++ b/frontend/src/components/AlertBanner/AlertBanner.module.css
@@ -2,3 +2,18 @@
   min-width: 100%;
   font-size: 14px;
 }
+
+/* Styles for HTML content in banner */
+.alertBannerText a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.alertBannerText a:hover {
+  text-decoration: none;
+}
+
+.alertBannerText strong,
+.alertBannerText b {
+  font-weight: bold;
+}

--- a/frontend/src/components/AlertBanner/AlertBanner.module.css
+++ b/frontend/src/components/AlertBanner/AlertBanner.module.css
@@ -1,10 +1,3 @@
-.alertBanner {
-  width: 99%;
-  margin: 0 auto;
-  box-sizing: border-box;
-  margin-top: 8px !important;
-}
-
 .alertBannerContent {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/components/AlertBanner/AlertBanner.module.css
+++ b/frontend/src/components/AlertBanner/AlertBanner.module.css
@@ -11,56 +11,7 @@
 }
 
 .closeButton {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  font-size: 24px;
-  line-height: 1;
-  font-weight: bold;
-  opacity: 0.7;
-  display: inline-block;
-  align-items: center;
-  justify-content: center;
-  height: auto;
-  min-height: 24px;
-  min-width: 24px;
   align-self: center;
-}
-
-.closeButton:hover {
-  opacity: 1;
-}
-
-.closeButton span {
-  position: relative;
-  top: -2px;
-}
-
-.closeX {
-  display: block;
-  width: 24px;
-  height: 24px;
-  position: relative;
-}
-
-.closeX:before,
-.closeX:after {
-  content: '';
-  position: absolute;
-  width: 100%;
-  height: 2px;
-  background-color: currentColor;
-  left: 0;
-  margin-right: 10px;
-}
-
-.closeX:before {
-  transform: rotate(45deg);
-}
-
-.closeX:after {
-  transform: rotate(-45deg);
 }
 
 /* Styles for HTML content in banner */

--- a/frontend/src/components/AlertBanner/AlertBanner.module.css
+++ b/frontend/src/components/AlertBanner/AlertBanner.module.css
@@ -1,6 +1,66 @@
+.alertBannerContent {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
 .alertBannerText {
-  min-width: 100%;
+  min-width: 90%;
   font-size: 14px;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  font-size: 24px;
+  line-height: 1;
+  font-weight: bold;
+  opacity: 0.7;
+  display: inline-block;
+  align-items: center;
+  justify-content: center;
+  height: auto;
+  min-height: 24px;
+  min-width: 24px;
+  align-self: center;
+}
+
+.closeButton:hover {
+  opacity: 1;
+}
+
+.closeButton span {
+  position: relative;
+  top: -2px;
+}
+
+.closeX {
+  display: block;
+  width: 24px;
+  height: 24px;
+  position: relative;
+}
+
+.closeX:before,
+.closeX:after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  background-color: currentColor;
+  left: 0;
+  margin-right: 10px;
+}
+
+.closeX:before {
+  transform: rotate(45deg);
+}
+
+.closeX:after {
+  transform: rotate(-45deg);
 }
 
 /* Styles for HTML content in banner */

--- a/frontend/src/components/AlertBanner/AlertBanner.module.css
+++ b/frontend/src/components/AlertBanner/AlertBanner.module.css
@@ -8,6 +8,7 @@
 .alertBannerText {
   min-width: 90%;
   font-size: 14px;
+  margin-left: 4px;
 }
 
 .closeButton {

--- a/frontend/src/components/AlertBanner/AlertBanner.module.css
+++ b/frontend/src/components/AlertBanner/AlertBanner.module.css
@@ -14,7 +14,7 @@
 
 .alertBannerText {
   min-width: 90%;
-  font-size: 14px;
+  font-size: 0.875rem;
   margin-left: 4px;
 }
 

--- a/frontend/src/components/AlertBanner/AlertBanner.module.css
+++ b/frontend/src/components/AlertBanner/AlertBanner.module.css
@@ -1,3 +1,10 @@
+.alertBanner {
+  width: 99%;
+  margin: 0 auto;
+  box-sizing: border-box;
+  margin-top: 8px !important;
+}
+
 .alertBannerContent {
   display: flex;
   justify-content: space-between;
@@ -15,7 +22,6 @@
   align-self: center;
 }
 
-/* Styles for HTML content in banner */
 .alertBannerText a {
   color: inherit;
   text-decoration: underline;

--- a/frontend/src/components/AlertBanner/AlertBanner.test.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.test.tsx
@@ -4,11 +4,9 @@ import "@testing-library/jest-dom";
 
 import { AlertBanner, AlertType } from "./AlertBanner";
 
-// Test constants
 const DEFAULT_ALERT_MESSAGE = "This is an alert!";
 const DEFAULT_ALERT_ID = "test-alert";
 
-// Helper functions
 const renderAlertBanner = (props: Partial<React.ComponentProps<typeof AlertBanner>> = {}) => {
   const defaultProps = {
     message: DEFAULT_ALERT_MESSAGE,
@@ -27,7 +25,6 @@ const queryCloseButton = () => screen.queryByRole('button', { name: /close alert
 describe("<AlertBanner>", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Mock localStorage
     const localStorageMock = {
       getItem: jest.fn(() => null),
       setItem: jest.fn(),
@@ -102,7 +99,6 @@ describe("<AlertBanner>", () => {
     });
 
     it("does not show banner if previously dismissed in localStorage", () => {
-      // Setup localStorage mock to simulate previously dismissed alert
       localStorage.getItem = jest.fn(() => 'true');
       
       renderAlertBanner({ dismissible: true, id: DEFAULT_ALERT_ID });
@@ -115,7 +111,6 @@ describe("<AlertBanner>", () => {
       const dismissedBannerId = "dismissed-banner";
       const newBannerId = "new-banner";
       
-      // Setup localStorage to simulate a previously dismissed banner with different ID
       localStorage.getItem = jest.fn((key) => {
         if (key === `dismissed-alert-banner-${dismissedBannerId}`) {
           return 'true';

--- a/frontend/src/components/AlertBanner/AlertBanner.test.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.test.tsx
@@ -4,10 +4,45 @@ import "@testing-library/jest-dom";
 
 import { AlertBanner, AlertType } from "./AlertBanner";
 
+// Test constants
+const DEFAULT_ALERT_MESSAGE = "This is an alert!";
+const DEFAULT_ALERT_ID = "test-alert";
+
+// Helper functions
+const renderAlertBanner = (props: Partial<React.ComponentProps<typeof AlertBanner>> = {}) => {
+  const defaultProps = {
+    message: DEFAULT_ALERT_MESSAGE,
+    alertType: AlertType.INFO,
+    id: DEFAULT_ALERT_ID,
+  };
+  
+  return render(<AlertBanner {...defaultProps} {...props} />);
+};
+
+const getAlertBanner = () => screen.getByTestId("alert-banner");
+const queryAlertBanner = () => screen.queryByTestId("alert-banner");
+const getCloseButton = () => screen.getByRole('button', { name: /close alert banner/i });
+const queryCloseButton = () => screen.queryByRole('button', { name: /close alert banner/i });
+
 describe("<AlertBanner>", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Mock localStorage
+    const localStorageMock = {
+      getItem: jest.fn(() => null),
+      setItem: jest.fn(),
+      clear: jest.fn(),
+    };
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it("renders the 'messageHtml' prop in a paragraph element with the 'usa-alert__text' class", () => {
     const alertMessage = "This is an alert!";
-    render(<AlertBanner message={alertMessage} alertType={AlertType.INFO} id="test-alert-1" />);
+    renderAlertBanner({ message: alertMessage, alertType: AlertType.INFO, id: "test-alert-1" });
     const alertTextElement = screen.getByText(alertMessage);
     expect(alertTextElement).toBeInTheDocument();
     expect(alertTextElement).toHaveRole("paragraph");
@@ -16,7 +51,7 @@ describe("<AlertBanner>", () => {
 
   it("is styled to be a USWDS alert (slim, no icon)", () => {
     const expectedClasses = ["usa-alert", "usa-alert--slim", "usa-alert--no-icon"];
-    render(<AlertBanner message="" alertType={AlertType.INFO} id="test-alert-2" />);
+    renderAlertBanner({ message: "", alertType: AlertType.INFO, id: "test-alert-2" });
     const alertBanner = screen.getByTestId("alert-banner");
     for (const expectedClass of expectedClasses) {
       expect(alertBanner).toHaveClass(expectedClass);
@@ -25,72 +60,73 @@ describe("<AlertBanner>", () => {
 
   describe("sets the USWDS alert type based on the 'alertType' prop", () => {
     it.each(Object.values(AlertType))("alert type: %s", (alertType) => {
-      render(<AlertBanner message="" alertType={alertType} id={`test-alert-${alertType}`} />);
+      renderAlertBanner({ message: "", alertType, id: `test-alert-${alertType}` });
       expect(screen.getByTestId("alert-banner")).toHaveClass(`usa-alert--${alertType}`);
     });
   });
 
-  describe("CloseButton functionality", () => {
-    beforeEach(() => {
-      // Mock localStorage
-      const localStorageMock = {
-        getItem: jest.fn(() => null),
-        setItem: jest.fn(),
-        clear: jest.fn(),
-      };
-      Object.defineProperty(window, 'localStorage', { value: localStorageMock });
-    });
-
+  describe("dismissible functionality", () => {
     it("shows the CloseButton when dismissible prop is true", () => {
-      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={true} id="test-alert" />);
-      
-      const closeButton = screen.getByRole('button', { name: /close alert banner/i });
-      expect(closeButton).toBeInTheDocument();
+      renderAlertBanner({ dismissible: true });
+      expect(getCloseButton()).toBeInTheDocument();
     });
 
     it("does not show the CloseButton when dismissible prop is false", () => {
-      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={false} id="test-alert" />);
-      
-      const closeButton = screen.queryByRole('button', { name: /close alert banner/i });
-      expect(closeButton).not.toBeInTheDocument();
+      renderAlertBanner({ dismissible: false });
+      expect(queryCloseButton()).not.toBeInTheDocument();
     });
 
     it("does not show the CloseButton when dismissible prop is undefined", () => {
-      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} id="test-alert" />);
-      
-      const closeButton = screen.queryByRole('button', { name: /close alert banner/i });
-      expect(closeButton).not.toBeInTheDocument();
+      renderAlertBanner();
+      expect(queryCloseButton()).not.toBeInTheDocument();
     });
+  });
 
+  describe("dismissal behavior", () => {
     it("hides the banner when CloseButton is clicked", () => {
-      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={true} id="test-alert" />);
+      renderAlertBanner({ dismissible: true });
       
-      const banner = screen.getByTestId("alert-banner");
-      expect(banner).toBeInTheDocument();
+      expect(getAlertBanner()).toBeInTheDocument();
       
-      const closeButton = screen.getByRole('button', { name: /close alert banner/i });
-      fireEvent.click(closeButton);
+      fireEvent.click(getCloseButton());
       
-      expect(screen.queryByTestId("alert-banner")).not.toBeInTheDocument();
+      expect(queryAlertBanner()).not.toBeInTheDocument();
     });
 
     it("saves dismissal state to localStorage when closed", () => {
-      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={true} id="test-alert" />);
+      renderAlertBanner({ dismissible: true, id: DEFAULT_ALERT_ID });
       
-      const closeButton = screen.getByRole('button', { name: /close alert banner/i });
-      fireEvent.click(closeButton);
+      fireEvent.click(getCloseButton());
       
-      expect(localStorage.setItem).toHaveBeenCalledWith('dismissed-alert-banner-test-alert', 'true');
+      expect(localStorage.setItem).toHaveBeenCalledWith(`dismissed-alert-banner-${DEFAULT_ALERT_ID}`, 'true');
     });
 
-    it("doesn't show banner if previously dismissed in localStorage", () => {
+    it("does not show banner if previously dismissed in localStorage", () => {
       // Setup localStorage mock to simulate previously dismissed alert
       localStorage.getItem = jest.fn(() => 'true');
       
-      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={true} id="test-alert" />);
+      renderAlertBanner({ dismissible: true, id: DEFAULT_ALERT_ID });
       
-      expect(screen.queryByTestId("alert-banner")).not.toBeInTheDocument();
-      expect(localStorage.getItem).toHaveBeenCalledWith('dismissed-alert-banner-test-alert');
+      expect(queryAlertBanner()).not.toBeInTheDocument();
+      expect(localStorage.getItem).toHaveBeenCalledWith(`dismissed-alert-banner-${DEFAULT_ALERT_ID}`);
+    });
+
+    it("renders a new banner with different id even if another banner was previously dismissed", () => {
+      const dismissedBannerId = "dismissed-banner";
+      const newBannerId = "new-banner";
+      
+      // Setup localStorage to simulate a previously dismissed banner with different ID
+      localStorage.getItem = jest.fn((key) => {
+        if (key === `dismissed-alert-banner-${dismissedBannerId}`) {
+          return 'true';
+        }
+        return null;
+      });
+      
+      renderAlertBanner({ dismissible: true, id: newBannerId });
+      
+      expect(getAlertBanner()).toBeInTheDocument();
+      expect(localStorage.getItem).toHaveBeenCalledWith(`dismissed-alert-banner-${newBannerId}`);
     });
   });
 });

--- a/frontend/src/components/AlertBanner/AlertBanner.test.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.test.tsx
@@ -80,7 +80,7 @@ describe("<AlertBanner>", () => {
       const closeButton = screen.getByRole('button', { name: /close alert banner/i });
       fireEvent.click(closeButton);
       
-      expect(localStorage.setItem).toHaveBeenCalledWith('dismissed-alert-test-alert', 'true');
+      expect(localStorage.setItem).toHaveBeenCalledWith('dismissed-alert-banner-test-alert', 'true');
     });
 
     it("doesn't show banner if previously dismissed in localStorage", () => {
@@ -90,7 +90,7 @@ describe("<AlertBanner>", () => {
       render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={true} id="test-alert" />);
       
       expect(screen.queryByTestId("alert-banner")).not.toBeInTheDocument();
-      expect(localStorage.getItem).toHaveBeenCalledWith('dismissed-alert-test-alert');
+      expect(localStorage.getItem).toHaveBeenCalledWith('dismissed-alert-banner-test-alert');
     });
   });
 });

--- a/frontend/src/components/AlertBanner/AlertBanner.test.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 import "@testing-library/jest-dom";
 
@@ -7,7 +7,7 @@ import { AlertBanner, AlertType } from "./AlertBanner";
 describe("<AlertBanner>", () => {
   it("renders the 'messageHtml' prop in a paragraph element with the 'usa-alert__text' class", () => {
     const alertMessage = "This is an alert!";
-    render(<AlertBanner message={alertMessage} alertType={AlertType.INFO} />);
+    render(<AlertBanner message={alertMessage} alertType={AlertType.INFO} id="test-alert-1" />);
     const alertTextElement = screen.getByText(alertMessage);
     expect(alertTextElement).toBeInTheDocument();
     expect(alertTextElement).toHaveRole("paragraph");
@@ -16,7 +16,7 @@ describe("<AlertBanner>", () => {
 
   it("is styled to be a USWDS alert (slim, no icon)", () => {
     const expectedClasses = ["usa-alert", "usa-alert--slim", "usa-alert--no-icon"];
-    render(<AlertBanner message="" alertType={AlertType.INFO} />);
+    render(<AlertBanner message="" alertType={AlertType.INFO} id="test-alert-2" />);
     const alertBanner = screen.getByTestId("alert-banner");
     for (const expectedClass of expectedClasses) {
       expect(alertBanner).toHaveClass(expectedClass);
@@ -25,8 +25,72 @@ describe("<AlertBanner>", () => {
 
   describe("sets the USWDS alert type based on the 'alertType' prop", () => {
     it.each(Object.values(AlertType))("alert type: %s", (alertType) => {
-      render(<AlertBanner message="" alertType={alertType} />);
+      render(<AlertBanner message="" alertType={alertType} id={`test-alert-${alertType}`} />);
       expect(screen.getByTestId("alert-banner")).toHaveClass(`usa-alert--${alertType}`);
+    });
+  });
+
+  describe("CloseButton functionality", () => {
+    beforeEach(() => {
+      // Mock localStorage
+      const localStorageMock = {
+        getItem: jest.fn(() => null),
+        setItem: jest.fn(),
+        clear: jest.fn(),
+      };
+      Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+    });
+
+    it("shows the CloseButton when dismissible prop is true", () => {
+      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={true} id="test-alert" />);
+      
+      const closeButton = screen.getByRole('button', { name: /close alert banner/i });
+      expect(closeButton).toBeInTheDocument();
+    });
+
+    it("does not show the CloseButton when dismissible prop is false", () => {
+      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={false} id="test-alert" />);
+      
+      const closeButton = screen.queryByRole('button', { name: /close alert banner/i });
+      expect(closeButton).not.toBeInTheDocument();
+    });
+
+    it("does not show the CloseButton when dismissible prop is undefined", () => {
+      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} id="test-alert" />);
+      
+      const closeButton = screen.queryByRole('button', { name: /close alert banner/i });
+      expect(closeButton).not.toBeInTheDocument();
+    });
+
+    it("hides the banner when CloseButton is clicked", () => {
+      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={true} id="test-alert" />);
+      
+      const banner = screen.getByTestId("alert-banner");
+      expect(banner).toBeInTheDocument();
+      
+      const closeButton = screen.getByRole('button', { name: /close alert banner/i });
+      fireEvent.click(closeButton);
+      
+      expect(screen.queryByTestId("alert-banner")).not.toBeInTheDocument();
+    });
+
+    it("saves dismissal state to localStorage when closed", () => {
+      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={true} id="test-alert" />);
+      
+      const closeButton = screen.getByRole('button', { name: /close alert banner/i });
+      fireEvent.click(closeButton);
+      
+      expect(localStorage.setItem).toHaveBeenCalledWith('dismissed-alert-test-alert', 'true');
+    });
+
+    it("doesn't show banner if previously dismissed in localStorage", () => {
+      // Setup localStorage mock to simulate previously dismissed alert
+      localStorage.getItem = jest.fn(() => 'true');
+      
+      render(<AlertBanner message="Test Alert" alertType={AlertType.INFO} dismissible={true} id="test-alert" />);
+      
+      expect(screen.queryByTestId("alert-banner")).not.toBeInTheDocument();
+      expect(localStorage.getItem).toHaveBeenCalledWith('dismissed-alert-test-alert');
     });
   });
 });

--- a/frontend/src/components/AlertBanner/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.tsx
@@ -22,7 +22,10 @@ export const AlertBanner = (props: Props) => {
       className={`usa-alert usa-alert--${props.alertType} usa-alert--slim usa-alert--no-icon`}
     >
       <div className="usa-alert__body">
-        <p className={`${styles.alertBannerText} usa-alert__text`}>{props.message}</p>
+        <p 
+          className={`${styles.alertBannerText} usa-alert__text`}
+          dangerouslySetInnerHTML={{ __html: props.message }}
+        />
       </div>
     </div>
   );

--- a/frontend/src/components/AlertBanner/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.tsx
@@ -48,8 +48,7 @@ export const AlertBanner = (props: Props) => {
     return null;
   }
 
-  // Use the prop instead of environment variable
-  const canDismissBanner = props.dismissible !== false; // default to true if undefined
+  const canDismissBanner = props.dismissible === true;
 
   return (
     <div

--- a/frontend/src/components/AlertBanner/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import styles from "./AlertBanner.module.css";
 
 export const AlertType = {
@@ -13,19 +14,56 @@ export type AlertType = (typeof AlertType)[keyof typeof AlertType];
 interface Props {
   message: string;
   alertType: AlertType;
+  id?: string; // Unique identifier for this alert type
 }
 
 export const AlertBanner = (props: Props) => {
+  const alertId = props.id || `alert-${props.alertType}`;
+  const storageKey = `dismissed-alert-${alertId}`;
+
+  // Check localStorage on initial render
+  const [isVisible, setIsVisible] = useState(() => {
+    try {
+      return localStorage.getItem(storageKey) !== "true";
+    } catch (e) {
+      // In case localStorage is not available
+      return true;
+    }
+  });
+
+  const handleClose = () => {
+    try {
+      // Store the dismissal in localStorage
+      localStorage.setItem(storageKey, "true");
+    } catch (e) {
+      // Handle localStorage errors silently
+      console.error("Failed to save alert preference:", e);
+    }
+    setIsVisible(false);
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
   return (
     <div
       data-testid="alert-banner"
       className={`usa-alert usa-alert--${props.alertType} usa-alert--slim usa-alert--no-icon`}
     >
-      <div className="usa-alert__body">
-        <p 
+      <div className={styles.alertBannerContent}>
+        <p
           className={`${styles.alertBannerText} usa-alert__text`}
           dangerouslySetInnerHTML={{ __html: props.message }}
         />
+        <button
+          className={styles.closeButton}
+          onClick={handleClose}
+          aria-label="Close alert banner"
+          type="button"
+        >
+          <span aria-hidden="true" className={styles.closeX}></span>
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/AlertBanner/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.tsx
@@ -15,13 +15,13 @@ export type AlertType = (typeof AlertType)[keyof typeof AlertType];
 interface Props {
   message: string;
   alertType: AlertType;
-  dismissible?: boolean; // Fix typo in property name (was "dissmissible")
-  id?: string; // Unique identifier for this alert type
+  dismissible?: boolean; 
+  id: string; 
 }
 
 export const AlertBanner = (props: Props) => {
   const alertId = props.id || `alert-${props.alertType}`;
-  const storageKey = `dismissed-alert-${alertId}`;
+  const storageKey = `dismissed-alert-banner-${alertId}`;
 
   // Check localStorage on initial render
   const [isVisible, setIsVisible] = useState(() => {
@@ -39,7 +39,7 @@ export const AlertBanner = (props: Props) => {
       localStorage.setItem(storageKey, "true");
     } catch (e) {
       // Handle localStorage errors silently
-      console.error("Failed to save alert preference:", e);
+      return true;
     }
     setIsVisible(false);
   };

--- a/frontend/src/components/AlertBanner/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.tsx
@@ -15,6 +15,7 @@ export type AlertType = (typeof AlertType)[keyof typeof AlertType];
 interface Props {
   message: string;
   alertType: AlertType;
+  dismissible?: boolean; // Fix typo in property name (was "dissmissible")
   id?: string; // Unique identifier for this alert type
 }
 
@@ -47,6 +48,9 @@ export const AlertBanner = (props: Props) => {
     return null;
   }
 
+  // Use the prop instead of environment variable
+  const canDismissBanner = props.dismissible !== false; // default to true if undefined
+
   return (
     <div
       data-testid="alert-banner"
@@ -57,11 +61,13 @@ export const AlertBanner = (props: Props) => {
           className={`${styles.alertBannerText} usa-alert__text`}
           dangerouslySetInnerHTML={{ __html: props.message }}
         />
-        <CloseButton
-          ariaLabel="Close alert banner"
-          buttonClasses={styles.closeButton}
-          handleClick={handleClose}
-        />
+        {canDismissBanner && (
+          <CloseButton
+            ariaLabel="Close alert banner"
+            buttonClasses={styles.closeButton}
+            handleClick={handleClose}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/AlertBanner/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.tsx
@@ -49,7 +49,7 @@ export const AlertBanner = (props: Props) => {
   return (
     <div
       data-testid="alert-banner"
-      className={`usa-alert usa-alert--${props.alertType} usa-alert--slim usa-alert--no-icon ${styles.alertBanner}`}
+      className={`usa-alert usa-alert--${props.alertType} usa-alert--slim usa-alert--no-icon padding-1 margin-105`}
     >
       <div className={styles.alertBannerContent}>
         <p

--- a/frontend/src/components/AlertBanner/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.tsx
@@ -23,22 +23,18 @@ export const AlertBanner = (props: Props) => {
   const alertId = props.id || `alert-${props.alertType}`;
   const storageKey = `dismissed-alert-banner-${alertId}`;
 
-  // Check localStorage on initial render
   const [isVisible, setIsVisible] = useState(() => {
     try {
       return localStorage.getItem(storageKey) !== "true";
     } catch (e) {
-      // In case localStorage is not available
       return true;
     }
   });
 
   const handleClose = () => {
     try {
-      // Store the dismissal in localStorage
       localStorage.setItem(storageKey, "true");
     } catch (e) {
-      // Handle localStorage errors silently
       return true;
     }
     setIsVisible(false);
@@ -53,7 +49,7 @@ export const AlertBanner = (props: Props) => {
   return (
     <div
       data-testid="alert-banner"
-      className={`usa-alert usa-alert--${props.alertType} usa-alert--slim usa-alert--no-icon`}
+      className={`usa-alert usa-alert--${props.alertType} usa-alert--slim usa-alert--no-icon ${styles.alertBanner}`}
     >
       <div className={styles.alertBannerContent}>
         <p

--- a/frontend/src/components/AlertBanner/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner/AlertBanner.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import styles from "./AlertBanner.module.css";
+import { CloseButton } from "../common/Button";
 
 export const AlertType = {
   INFO: "info",
@@ -56,14 +57,11 @@ export const AlertBanner = (props: Props) => {
           className={`${styles.alertBannerText} usa-alert__text`}
           dangerouslySetInnerHTML={{ __html: props.message }}
         />
-        <button
-          className={styles.closeButton}
-          onClick={handleClose}
-          aria-label="Close alert banner"
-          type="button"
-        >
-          <span aria-hidden="true" className={styles.closeX}></span>
-        </button>
+        <CloseButton
+          ariaLabel="Close alert banner"
+          buttonClasses={styles.closeButton}
+          handleClick={handleClose}
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/layout/Layout.tsx
+++ b/frontend/src/pages/layout/Layout.tsx
@@ -95,7 +95,7 @@ const Layout = () => {
             message={ui.alert_banner_message}
             alertType={alertType}
             dismissible={ui.alert_banner_dismissible}
-            id="main-alert-banner"
+            id={ui.alert_banner_id || "alert"}
           />
         )}
         <Stack horizontal verticalAlign="center" horizontalAlign="space-between">

--- a/frontend/src/pages/layout/Layout.tsx
+++ b/frontend/src/pages/layout/Layout.tsx
@@ -91,7 +91,12 @@ const Layout = () => {
     <div className={styles.layout}>
       <header className={styles.header} role={"banner"}>
         {ui?.alert_banner_message != null && ui.alert_banner_message.trim().length > 0 && (
-          <AlertBanner message={ui.alert_banner_message} alertType={alertType} />
+          <AlertBanner
+            message={ui.alert_banner_message}
+            alertType={alertType}
+            dismissible={ui.alert_banner_dismissible}
+            id="main-alert-banner"
+          />
         )}
         <Stack horizontal verticalAlign="center" horizontalAlign="space-between">
           <Stack horizontal verticalAlign="center">


### PR DESCRIPTION
### Motivation and Context

Adds needed changes to display the survey banner. 

### Description

Updates AlertBanner.tsx and the associated CSS file to add the banner element, with a close button that persists across sessions. Adds an environment variable UI_ALERT_BANNER_DISMISSIBLE to control the close button.

<img width="1919" height="852" alt="image" src="https://github.com/user-attachments/assets/d1d158db-b6bd-431e-ab3f-3091b1a1c997" />

### Contribution Checklist

- [x] I have built and tested the code locally and in a deployed app
- [x] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [x] I didn't break any existing functionality :smile:
