### PR TITLE
Added copy prompt/answer functionality to frontend

### DIFF
--- a/frontend/src/components/Answer/Answer.tsx
+++ b/frontend/src/components/Answer/Answer.tsx
@@ -374,6 +374,7 @@ export const Answer = ({
           {answer.message_id !== undefined && (
             <Stack.Item className={"margin-left-2"}>
               <button
+                data-testid="answer-copy-button"
                 className={`usa-button usa-button--unstyled text-no-underline display-flex`}
                 aria-label={`Copy answer to clipboard that begins with "${answer.answer.split(" ").slice(0, 3)}…"`}
                 onClick={() => onCopyClicked(answer.answer)}

--- a/frontend/src/components/Answer/Answer.tsx
+++ b/frontend/src/components/Answer/Answer.tsx
@@ -7,6 +7,7 @@ import { nord } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { Checkbox, DefaultButton, Dialog, FontIcon, Stack, Text } from "@fluentui/react";
 import { useBoolean } from "@fluentui/react-hooks";
 import { ThumbDislike20Filled, ThumbLike20Filled } from "@fluentui/react-icons";
+import icons from "@newjersey/njwds/dist/img/sprite.svg";
 import DOMPurify from "dompurify";
 import remarkGfm from "remark-gfm";
 import supersub from "remark-supersub";
@@ -24,9 +25,15 @@ interface Props {
   answer: AskResponse;
   onCitationClicked: (citedDocument: Citation) => void;
   onExectResultClicked: () => void;
+  onCopyClicked: (text: string) => void;
 }
 
-export const Answer = ({ answer, onCitationClicked, onExectResultClicked }: Props) => {
+export const Answer = ({
+  answer,
+  onCitationClicked,
+  onExectResultClicked,
+  onCopyClicked,
+}: Props) => {
   const initializeAnswerFeedback = (answer: AskResponse) => {
     if (answer.message_id == undefined) return undefined;
     if (answer.feedback == undefined) return undefined;
@@ -364,6 +371,20 @@ export const Answer = ({ answer, onCitationClicked, onExectResultClicked }: Prop
           <Stack.Item className={styles.answerDisclaimerContainer}>
             <span className={styles.answerDisclaimer}>AI-generated content may be incorrect</span>
           </Stack.Item>
+          {answer.message_id !== undefined && (
+            <Stack.Item className={"margin-left-2"}>
+              <button
+                className={`usa-button usa-button--unstyled text-no-underline display-flex`}
+                aria-label="Copy Answer to Clipboard"
+                onClick={() => onCopyClicked(answer.answer)}
+              >
+                Copy
+                <svg className="usa-icon" aria-hidden="true" focusable="false" role="img">
+                  <use href={`${icons}#content_copy`} />
+                </svg>
+              </button>
+            </Stack.Item>
+          )}
           {!!answer.exec_results?.length && (
             <Stack.Item
               onKeyDown={(e) =>

--- a/frontend/src/components/Answer/Answer.tsx
+++ b/frontend/src/components/Answer/Answer.tsx
@@ -375,7 +375,7 @@ export const Answer = ({
             <Stack.Item className={"margin-left-2"}>
               <button
                 className={`usa-button usa-button--unstyled text-no-underline display-flex`}
-                aria-label="Copy Answer to Clipboard"
+                aria-label={`Copy answer to clipboard that begins with "${answer.answer.split(" ").slice(0, 3)}…"`}
                 onClick={() => onCopyClicked(answer.answer)}
               >
                 Copy

--- a/frontend/src/components/Answer/Answer.tsx
+++ b/frontend/src/components/Answer/Answer.tsx
@@ -375,12 +375,17 @@ export const Answer = ({
             <Stack.Item className={"margin-left-2"}>
               <button
                 data-testid="answer-copy-button"
-                className={`usa-button usa-button--unstyled text-no-underline display-flex`}
-                aria-label={`Copy answer to clipboard that begins with "${answer.answer.split(" ").slice(0, 3)}…"`}
+                className={`usa-button usa-button--unstyled text-no-underline display-flex font-sans-xs`}
+                aria-label={`Copy response to clipboard that begins with "${answer.answer.split(" ").slice(0, 3).join(" ")}…"`}
                 onClick={() => onCopyClicked(answer.answer)}
               >
                 Copy
-                <svg className="usa-icon" aria-hidden="true" focusable="false" role="img">
+                <svg
+                  className="usa-icon usa-icon--size-2"
+                  aria-hidden="true"
+                  focusable="false"
+                  role="img"
+                >
                   <use href={`${icons}#content_copy`} />
                 </svg>
               </button>

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -39,6 +39,7 @@ interface CloseButtonProps {
 export const CloseButton = (props: CloseButtonProps) => {
   return (
     <button
+      data-testid="close-button"
       className={`usa-button usa-button--unstyled ${props.buttonClasses ?? ""}`}
       onClick={props.handleClick}
       aria-label={props.ariaLabel}

--- a/frontend/src/pages/chat/Chat.module.css
+++ b/frontend/src/pages/chat/Chat.module.css
@@ -379,3 +379,7 @@ img.previewImage {
   margin-top: 10px;
   text-align: right;
 }
+
+.chatCopy {
+  flex-direction: row !important;
+}

--- a/frontend/src/pages/chat/Chat.test.tsx
+++ b/frontend/src/pages/chat/Chat.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe, toHaveNoViolations } from "jest-axe";
 
@@ -178,21 +178,17 @@ describe("Test copy prompt/response", () => {
     // Submit a query, make sure the prompt appears
     await inputChatMessage();
     clickSubmitButton();
-    await waitFor(() => {
-      expect(screen.queryByText("Copy")).toBeInTheDocument();
-    });
+    expect(await screen.findByText("Copy")).toBeInTheDocument();
 
     // Copy the prompt, check that the correct alert shows up
     userEvent.setup(); // Enable clipboard to work
     const copyPromptButton = screen.getByTestId("prompt-copy-button");
-    fireEvent.click(copyPromptButton);
-    await waitFor(() => {
-      expect(screen.queryByText("Prompt copied to clipboard.")).toBeInTheDocument();
-    });
+    await userEvent.click(copyPromptButton);
+    expect(await screen.findByText("Prompt copied to clipboard.")).toBeInTheDocument();
 
     // Close the alert
     const closeButton = screen.getByTestId("close-button");
-    fireEvent.click(closeButton);
+    await userEvent.click(closeButton);
     await waitFor(() => {
       expect(screen.queryByText("Prompt copied to clipboard.")).not.toBeInTheDocument();
     });

--- a/frontend/src/pages/chat/Chat.test.tsx
+++ b/frontend/src/pages/chat/Chat.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe, toHaveNoViolations } from "jest-axe";
 
@@ -151,6 +151,50 @@ describe("Test uploaded image previews", () => {
       expect(screen.queryByAltText(`${uploadedFileOne.name}`)).toBeInTheDocument();
       expect(screen.queryByAltText(`${uploadedFileTwo.name}`)).not.toBeInTheDocument();
       expect(screen.queryByAltText(`${uploadedFileThree.name}`)).toBeInTheDocument();
+    });
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("Test copy prompt/response", () => {
+  beforeEach(() => {
+    const defaultMockResponse = {
+      status: 200,
+    } as unknown as Response;
+
+    jest
+      .spyOn(api, "conversationApi")
+      .mockImplementation(() => Promise.resolve(defaultMockResponse));
+
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(jest.clearAllMocks);
+
+  it("renders prompt copy text", async () => {
+    const { container } = render(<Chat />);
+
+    // Submit a query, make sure the prompt appears
+    await inputChatMessage();
+    clickSubmitButton();
+    await waitFor(() => {
+      expect(screen.queryByText("Copy")).toBeInTheDocument();
+    });
+
+    // Copy the prompt, check that the correct alert shows up
+    userEvent.setup(); // Enable clipboard to work
+    const copyPromptButton = screen.getByTestId("prompt-copy-button");
+    fireEvent.click(copyPromptButton);
+    await waitFor(() => {
+      expect(screen.queryByText("Prompt copied to clipboard.")).toBeInTheDocument();
+    });
+
+    // Close the alert
+    const closeButton = screen.getByTestId("close-button");
+    fireEvent.click(closeButton);
+    await waitFor(() => {
+      expect(screen.queryByText("Prompt copied to clipboard.")).not.toBeInTheDocument();
     });
 
     expect(await axe(container)).toHaveNoViolations();

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -36,6 +36,7 @@ import NjLogo from "../../assets/nj-logo.svg";
 import { Answer } from "../../components/Answer";
 import { ChatHistoryPanel } from "../../components/ChatHistory/ChatHistoryPanel";
 import * as CoachMark from "../../components/CoachMark/CoachMark";
+import { CloseButton } from "../../components/common/Button";
 import { QuestionInput } from "../../components/QuestionInput";
 import { DEFAULT_CHAT_TITLE } from "../../constants/defaultAppState";
 import { XSSAllowTags } from "../../constants/sanatizeAllowables";
@@ -70,6 +71,8 @@ export const Chat = () => {
   const [clearingChat, setClearingChat] = useState<boolean>(false);
   const [hideErrorDialog, { toggle: toggleErrorDialog }] = useBoolean(true);
   const [errorMsg, setErrorMsg] = useState<ErrorMessage | null>();
+  const [copyText, setCopyText] = useState<string>("");
+  const [copyAlert, setCopyAlert] = useState<boolean>(false);
 
   const errorDialogContentProps = {
     type: DialogType.close,
@@ -782,6 +785,13 @@ export const Chat = () => {
     setIsIntentsPanelOpen(true);
   };
 
+  const onCopy = (text: string, isPrompt: boolean) => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopyText(`${isPrompt ? "Prompt" : "Response"} copied to clipboard.`);
+      setCopyAlert(true);
+    });
+  };
+
   const onViewSource = (citation: Citation) => {
     if (citation.url && !citation.url.includes("blob.core")) {
       window.open(citation.url, "_blank");
@@ -1017,6 +1027,25 @@ export const Chat = () => {
                           <div className="display-flex flex-row flex-align-end flex-justify-end">
                             {answer.content}
                           </div>
+                          <div className="display-flex flex-row flex-align-end flex-justify-end margin-top-1">
+                            <button
+                              className={`usa-button usa-button--unstyled text-no-underline display-flex`}
+                              aria-label="Copy Prompt to Clipboard"
+                              onClick={() => {
+                                onCopy(answer.content, true);
+                              }}
+                            >
+                              Copy
+                              <svg
+                                className="usa-icon"
+                                aria-hidden="true"
+                                focusable="false"
+                                role="img"
+                              >
+                                <use href={`${icons}#content_copy`} />
+                              </svg>
+                            </button>
+                          </div>
                           {answer.uploaded_files != null && answer.uploaded_files.length > 0 && (
                             <div className={`${styles.userAttachmentDisclaimer}`}>
                               {getUserAttachmentDisclaimerText(answer.uploaded_files)}
@@ -1037,6 +1066,7 @@ export const Chat = () => {
                           }}
                           onCitationClicked={(c) => onShowCitation(c)}
                           onExectResultClicked={() => onShowExecResult()}
+                          onCopyClicked={(text) => onCopy(text, false)}
                         />
                       </div>
                     ) : answer.role === ERROR ? (
@@ -1064,6 +1094,7 @@ export const Chat = () => {
                         }}
                         onCitationClicked={() => null}
                         onExectResultClicked={() => null}
+                        onCopyClicked={() => null}
                       />
                     </div>
                   </>
@@ -1088,6 +1119,20 @@ export const Chat = () => {
                   </span>
                 </Stack>
               )}
+              <div role="status" className="display-flex width-full margin-left-15 margin-right-15">
+                {copyAlert && (
+                  <div className="usa-alert usa-alert--success usa-alert--slim width-full margin-left-8">
+                    <div className={`usa-alert__body ${styles.chatCopy}`}>
+                      <p className="usa-alert__text flex-fill flex-justify-start">{copyText}</p>
+                      <CloseButton
+                        ariaLabel="Close copy alert"
+                        buttonClasses="flex-1 flex-justify-end"
+                        handleClick={() => setCopyAlert(false)}
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
               <div className="display-flex width-full">
                 <Stack className="flex-justify-end margin-bottom-5">
                   {isCosmosDbConfigured() && (

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -7,6 +7,7 @@ import { useBoolean } from "@fluentui/react-hooks";
 import { ErrorCircleRegular, ShieldLockRegular, SquareRegular } from "@fluentui/react-icons";
 import icons from "@newjersey/njwds/dist/img/sprite.svg";
 import DOMPurify from "dompurify";
+import { motion } from "framer-motion";
 import { isEmpty } from "lodash";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
@@ -46,7 +47,6 @@ import { isImageFile, truncateFilename } from "../../utils/fileUploadUtils";
 import { logEvent } from "../../utils/logEvent";
 
 import styles from "./Chat.module.css";
-import { motion } from "framer-motion";
 
 const enum messageStatus {
   NotRunning = "Not Running",
@@ -787,6 +787,10 @@ export const Chat = () => {
   };
 
   const onCopy = (text: string, isPrompt: boolean) => {
+    // Hide the copy alert temporarily before flashing a new one (to make it obvious to users
+    // that the new text was copied, & refire aria live region as well).
+    setCopyAlert(false);
+
     navigator.clipboard.writeText(text).then(() => {
       setCopyText(`${isPrompt ? "Prompt" : "Response"} copied to clipboard.`);
       setCopyAlert(true);

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -1030,7 +1030,7 @@ export const Chat = () => {
                           <div className="display-flex flex-row flex-align-end flex-justify-end margin-top-1">
                             <button
                               className={`usa-button usa-button--unstyled text-no-underline display-flex`}
-                              aria-label="Copy Prompt to Clipboard"
+                              aria-label={`Copy prompt to clipboard that begins with "${answer.content.split(" ").slice(0, 3)}…"`}
                               onClick={() => {
                                 onCopy(answer.content, true);
                               }}

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -46,6 +46,7 @@ import { isImageFile, truncateFilename } from "../../utils/fileUploadUtils";
 import { logEvent } from "../../utils/logEvent";
 
 import styles from "./Chat.module.css";
+import { motion } from "framer-motion";
 
 const enum messageStatus {
   NotRunning = "Not Running",
@@ -1122,7 +1123,11 @@ export const Chat = () => {
               )}
               <div role="status" className="display-flex width-full margin-left-15 margin-right-15">
                 {copyAlert && (
-                  <div className="usa-alert usa-alert--success usa-alert--slim width-full margin-left-8">
+                  <motion.div
+                    className="usa-alert usa-alert--success usa-alert--slim width-full margin-left-8"
+                    initial={{ y: 44, opacity: 0 }}
+                    animate={{ y: 0, opacity: 1 }}
+                  >
                     <div className={`usa-alert__body ${styles.chatCopy}`}>
                       <p className="usa-alert__text flex-fill flex-justify-start">{copyText}</p>
                       <CloseButton
@@ -1131,7 +1136,7 @@ export const Chat = () => {
                         handleClick={() => setCopyAlert(false)}
                       />
                     </div>
-                  </div>
+                  </motion.div>
                 )}
               </div>
               <div className="display-flex width-full">

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -1029,6 +1029,7 @@ export const Chat = () => {
                           </div>
                           <div className="display-flex flex-row flex-align-end flex-justify-end margin-top-1">
                             <button
+                              data-testid="prompt-copy-button"
                               className={`usa-button usa-button--unstyled text-no-underline display-flex`}
                               aria-label={`Copy prompt to clipboard that begins with "${answer.content.split(" ").slice(0, 3)}…"`}
                               onClick={() => {

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -1035,15 +1035,15 @@ export const Chat = () => {
                           <div className="display-flex flex-row flex-align-end flex-justify-end margin-top-1">
                             <button
                               data-testid="prompt-copy-button"
-                              className={`usa-button usa-button--unstyled text-no-underline display-flex`}
-                              aria-label={`Copy prompt to clipboard that begins with "${answer.content.split(" ").slice(0, 3)}…"`}
+                              className={`usa-button usa-button--unstyled text-no-underline display-flex font-sans-xs`}
+                              aria-label={`Copy prompt to clipboard that begins with "${answer.content.split(" ").slice(0, 3).join(" ")}…"`}
                               onClick={() => {
                                 onCopy(answer.content, true);
                               }}
                             >
                               Copy
                               <svg
-                                className="usa-icon"
+                                className="usa-icon usa-icon--size-2"
                                 aria-hidden="true"
                                 focusable="false"
                                 role="img"


### PR DESCRIPTION
## Description

https://github.com/orgs/newjersey/projects/81/views/14?pane=issue&itemId=133886295&issue=newjersey%7Cinnovation-platform-pm%7C709

Not proud of the !important but this project is in maintenance mode so one little !important won't kill us.

<img width="846" height="859" alt="image" src="https://github.com/user-attachments/assets/ddeaab0a-e9a7-4377-8be8-9ff8ea240133" />


## Accessibility
- [x] I have added unit tests for the front-end that use [appropriate Testing Library queries](https://testing-library.com/docs/queries/about#priority) and [jest-axe](https://www.npmjs.com/package/jest-axe) where applicable
- [x] I have both manually verified and written unit tests to ensure that all interactive elements are [keyboard navigable](https://webaim.org/techniques/keyboard/) and there are no [focus traps](https://www.w3.org/TR/UNDERSTANDING-WCAG20/keyboard-operation-trapping.html).
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).
- [x] I have check that text can be zoomed up to 200% without losing functionality ([WCAG 1.4.4](https://aaardvarkaccessibility.com/wcag-plain-english/1-4-4-resize-text/)).
- [x] I have tested changes with a screenreader (Note screenreader & browser, e.g. VoiceOver/Safari)

## How should a reviewer test?
<!-- Describe the testing approach taken to verify the changes, including unit/integration/manual tests and test data used-->
