### PR TITLE
Added log event for copying text to clipboard

### DIFF
--- a/frontend/src/pages/chat/Chat.test.tsx
+++ b/frontend/src/pages/chat/Chat.test.tsx
@@ -7,6 +7,7 @@ import "@testing-library/jest-dom";
 import * as api from "../../api";
 import { createMockFile } from "../../test/factories";
 import { ACCEPTED_FILE_TYPES } from "../../utils/fileUploadUtils";
+import * as logEvent from "../../utils/logEvent";
 
 import { Chat } from "./Chat";
 jest.mock("../../api");
@@ -175,6 +176,8 @@ describe("Test copy prompt/response", () => {
   it("renders prompt copy text", async () => {
     const { container } = render(<Chat />);
 
+    const logEventSpy = jest.spyOn(logEvent, "logEvent");
+
     // Submit a query, make sure the prompt appears
     await inputChatMessage();
     clickSubmitButton();
@@ -185,6 +188,9 @@ describe("Test copy prompt/response", () => {
     const copyPromptButton = screen.getByTestId("prompt-copy-button");
     await userEvent.click(copyPromptButton);
     expect(await screen.findByText("Prompt copied to clipboard.")).toBeInTheDocument();
+
+    expect(logEventSpy).toHaveBeenCalledWith("copy_prompt_text", {});
+    expect(logEventSpy).toHaveBeenCalledTimes(1);
 
     // Close the alert
     const closeButton = screen.getByTestId("close-button");

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -794,6 +794,8 @@ export const Chat = () => {
     navigator.clipboard.writeText(text).then(() => {
       setCopyText(`${isPrompt ? "Prompt" : "Response"} copied to clipboard.`);
       setCopyAlert(true);
+
+      logEvent(isPrompt ? "copy_prompt_text" : "copy_response_text", {});
     });
   };
 


### PR DESCRIPTION
## Description

https://github.com/newjersey/innovation-platform-pm/issues/712

Added two separate events - one for copying the prompt, another for copying the response.

I've also added the tags to GTM (but haven't setup a Looker view into it yet - going to wait for some events before I do that).

## Accessibility
- [x] I have added unit tests for the front-end that use [appropriate Testing Library queries](https://testing-library.com/docs/queries/about#priority) and [jest-axe](https://www.npmjs.com/package/jest-axe) where applicable
- [x] I have both manually verified and written unit tests to ensure that all interactive elements are [keyboard navigable](https://webaim.org/techniques/keyboard/) and there are no [focus traps](https://www.w3.org/TR/UNDERSTANDING-WCAG20/keyboard-operation-trapping.html).
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).
- [x] I have check that text can be zoomed up to 200% without losing functionality ([WCAG 1.4.4](https://aaardvarkaccessibility.com/wcag-plain-english/1-4-4-resize-text/)).
- [x] I have tested changes with a screenreader (Note screenreader & browser, e.g. VoiceOver/Safari)

## How should a reviewer test?
<!-- Describe the testing approach taken to verify the changes, including unit/integration/manual tests and test data used-->
