### PR TITLE
Added `file.pinned` & API for modifying it

### DIFF
--- a/api/nj/routes/files/files.js
+++ b/api/nj/routes/files/files.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const { logger } = require('@librechat/data-schemas');
+const { updateFileSchema } = require('librechat-data-provider');
+const db = require('~/models');
+
+const router = express.Router();
+
+// Custom NJ route which lets you modify a file's name or pinned status
+router.patch('/:file_id', async (req, res) => {
+  try {
+    const result = updateFileSchema.safeParse({ ...req.body, file_id: req.params.file_id });
+    if (!result.success) {
+      return res.status(400).json({ message: result.error.errors[0].message });
+    }
+    const { file_id, ...update } = result.data;
+    const file = await db.getFiles({ file_id, user: req.user.id });
+    if (!file.length) {
+      return res.status(404).json({ message: 'File not found' });
+    }
+    const updated = await db.updateFile({ file_id, ...update });
+    res.status(200).json(updated);
+  } catch (error) {
+    logger.error('[PATCH /files/:file_id] Error updating file', error);
+    res.status(500).json({ message: 'Error updating file', error: error.message });
+  }
+});
+
+module.exports = router;

--- a/api/nj/routes/files/files.js
+++ b/api/nj/routes/files/files.js
@@ -17,7 +17,7 @@ router.patch('/:file_id', async (req, res) => {
     if (!file.length) {
       return res.status(404).json({ message: 'File not found' });
     }
-    const updated = await db.updateFile({ file_id, ...update });
+    const updated = await db.updateFile({ file_id, ...update }, { user: req.user.id });
     res.status(200).json(updated);
   } catch (error) {
     logger.error('[PATCH /files/:file_id] Error updating file', error);

--- a/api/nj/routes/files/files.test.js
+++ b/api/nj/routes/files/files.test.js
@@ -1,0 +1,213 @@
+const express = require('express');
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+const { createMethods } = require('@librechat/data-schemas');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { SystemRoles } = require('librechat-data-provider');
+const { createFile } = require('~/models');
+
+jest.mock('@librechat/api', () => ({
+  ...jest.requireActual('@librechat/api'),
+  refreshS3FileUrls: jest.fn(),
+}));
+
+jest.mock('~/config', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const router = require('./files');
+
+// Note: tests designed to be placed in mainline files.test.js, if we ever decide to upstream this
+describe('PATCH /files/:file_id', () => {
+  let app;
+  let mongoServer;
+  let authorId;
+  let userId;
+  let fileId;
+  let File;
+  let User;
+  let methods;
+  let modelsToCleanup = [];
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+
+    const { createModels } = require('@librechat/data-schemas');
+    const models = createModels(mongoose);
+    modelsToCleanup = Object.keys(models);
+    Object.assign(mongoose.models, models);
+    methods = createMethods(mongoose);
+
+    File = models.File;
+    User = models.User;
+
+    await methods.seedDefaultRoles();
+
+    app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+      req.user = { id: userId?.toString() || 'default-user', role: SystemRoles.USER };
+      next();
+    });
+    app.use('/files', router);
+  });
+
+  afterAll(async () => {
+    const collections = mongoose.connection.collections;
+    for (const key in collections) {
+      await collections[key].deleteMany({});
+    }
+    for (const modelName of modelsToCleanup) {
+      delete mongoose.models[modelName];
+    }
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await File.deleteMany({});
+    await User.deleteMany({});
+
+    authorId = new mongoose.Types.ObjectId();
+    userId = new mongoose.Types.ObjectId();
+    fileId = uuidv4();
+
+    await User.create({ _id: authorId, username: 'author', email: 'author@test.com' });
+    await User.create({ _id: userId, username: 'user', email: 'user@test.com' });
+
+    await createFile({
+      user: authorId,
+      file_id: fileId,
+      filename: 'test.txt',
+      filepath: '/uploads/test.txt',
+      bytes: 100,
+      type: 'text/plain',
+    });
+  });
+
+  it('should pin a file owned by the user', async () => {
+    const userFileId = uuidv4();
+    await createFile({
+      user: userId,
+      file_id: userFileId,
+      filename: 'my-file.txt',
+      filepath: '/uploads/my-file.txt',
+      bytes: 100,
+      type: 'text/plain',
+    });
+
+    const response = await request(app).patch(`/files/${userFileId}`).send({ pinned: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.pinned).toBe(true);
+    expect(response.body.file_id).toBe(userFileId);
+  });
+
+  it('should rename a file owned by the user', async () => {
+    const userFileId = uuidv4();
+    await createFile({
+      user: userId,
+      file_id: userFileId,
+      filename: 'original.txt',
+      filepath: '/uploads/original.txt',
+      bytes: 100,
+      type: 'text/plain',
+    });
+
+    const response = await request(app)
+      .patch(`/files/${userFileId}`)
+      .send({ filename: 'renamed.txt' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.filename).toBe('renamed.txt');
+  });
+
+  it('should update both pinned and filename in one request', async () => {
+    const userFileId = uuidv4();
+    await createFile({
+      user: userId,
+      file_id: userFileId,
+      filename: 'original.txt',
+      filepath: '/uploads/original.txt',
+      bytes: 100,
+      type: 'text/plain',
+    });
+
+    const response = await request(app)
+      .patch(`/files/${userFileId}`)
+      .send({ pinned: true, filename: 'renamed.txt' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.pinned).toBe(true);
+    expect(response.body.filename).toBe('renamed.txt');
+  });
+
+  it('should return 404 for a file not owned by the user', async () => {
+    const response = await request(app).patch(`/files/${fileId}`).send({ pinned: true });
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('File not found');
+  });
+
+  it('should return 404 for a non-existent file', async () => {
+    const response = await request(app).patch(`/files/${uuidv4()}`).send({ pinned: true });
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('File not found');
+  });
+
+  it('should return 400 when no updatable fields are provided', async () => {
+    const userFileId = uuidv4();
+    await createFile({
+      user: userId,
+      file_id: userFileId,
+      filename: 'my-file.txt',
+      filepath: '/uploads/my-file.txt',
+      bytes: 100,
+      type: 'text/plain',
+    });
+
+    const response = await request(app).patch(`/files/${userFileId}`).send({});
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 when pinned is not a boolean', async () => {
+    const userFileId = uuidv4();
+    await createFile({
+      user: userId,
+      file_id: userFileId,
+      filename: 'my-file.txt',
+      filepath: '/uploads/my-file.txt',
+      bytes: 100,
+      type: 'text/plain',
+    });
+
+    const response = await request(app).patch(`/files/${userFileId}`).send({ pinned: 'yes' });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 when filename is an empty string', async () => {
+    const userFileId = uuidv4();
+    await createFile({
+      user: userId,
+      file_id: userFileId,
+      filename: 'my-file.txt',
+      filepath: '/uploads/my-file.txt',
+      bytes: 100,
+      type: 'text/plain',
+    });
+
+    const response = await request(app).patch(`/files/${userFileId}`).send({ filename: '' });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/api/nj/routes/files/files.test.js
+++ b/api/nj/routes/files/files.test.js
@@ -22,6 +22,17 @@ jest.mock('~/config', () => ({
 
 const router = require('./files');
 
+async function createFileHelper(userId, userFileId) {
+  return createFile({
+    user: userId,
+    file_id: userFileId,
+    filename: 'original.txt',
+    filepath: '/uploads/original.txt',
+    bytes: 100,
+    type: 'text/plain',
+  });
+}
+
 // Note: tests designed to be placed in mainline files.test.js, if we ever decide to upstream this
 describe('PATCH /files/:file_id', () => {
   let app;
@@ -82,26 +93,12 @@ describe('PATCH /files/:file_id', () => {
     await User.create({ _id: authorId, username: 'author', email: 'author@test.com' });
     await User.create({ _id: userId, username: 'user', email: 'user@test.com' });
 
-    await createFile({
-      user: authorId,
-      file_id: fileId,
-      filename: 'test.txt',
-      filepath: '/uploads/test.txt',
-      bytes: 100,
-      type: 'text/plain',
-    });
+    await createFileHelper(authorId, fileId);
   });
 
   it('should pin a file owned by the user', async () => {
     const userFileId = uuidv4();
-    await createFile({
-      user: userId,
-      file_id: userFileId,
-      filename: 'my-file.txt',
-      filepath: '/uploads/my-file.txt',
-      bytes: 100,
-      type: 'text/plain',
-    });
+    await createFileHelper(userId, userFileId);
 
     const response = await request(app).patch(`/files/${userFileId}`).send({ pinned: true });
 
@@ -112,14 +109,7 @@ describe('PATCH /files/:file_id', () => {
 
   it('should rename a file owned by the user', async () => {
     const userFileId = uuidv4();
-    await createFile({
-      user: userId,
-      file_id: userFileId,
-      filename: 'original.txt',
-      filepath: '/uploads/original.txt',
-      bytes: 100,
-      type: 'text/plain',
-    });
+    await createFileHelper(userId, userFileId);
 
     const response = await request(app)
       .patch(`/files/${userFileId}`)
@@ -131,14 +121,7 @@ describe('PATCH /files/:file_id', () => {
 
   it('should update both pinned and filename in one request', async () => {
     const userFileId = uuidv4();
-    await createFile({
-      user: userId,
-      file_id: userFileId,
-      filename: 'original.txt',
-      filepath: '/uploads/original.txt',
-      bytes: 100,
-      type: 'text/plain',
-    });
+    await createFileHelper(userId, userFileId);
 
     const response = await request(app)
       .patch(`/files/${userFileId}`)
@@ -165,14 +148,7 @@ describe('PATCH /files/:file_id', () => {
 
   it('should return 400 when no updatable fields are provided', async () => {
     const userFileId = uuidv4();
-    await createFile({
-      user: userId,
-      file_id: userFileId,
-      filename: 'my-file.txt',
-      filepath: '/uploads/my-file.txt',
-      bytes: 100,
-      type: 'text/plain',
-    });
+    await createFileHelper(userId, userFileId);
 
     const response = await request(app).patch(`/files/${userFileId}`).send({});
 
@@ -181,14 +157,7 @@ describe('PATCH /files/:file_id', () => {
 
   it('should return 400 when pinned is not a boolean', async () => {
     const userFileId = uuidv4();
-    await createFile({
-      user: userId,
-      file_id: userFileId,
-      filename: 'my-file.txt',
-      filepath: '/uploads/my-file.txt',
-      bytes: 100,
-      type: 'text/plain',
-    });
+    await createFileHelper(userId, userFileId);
 
     const response = await request(app).patch(`/files/${userFileId}`).send({ pinned: 'yes' });
 
@@ -197,14 +166,7 @@ describe('PATCH /files/:file_id', () => {
 
   it('should return 400 when filename is an empty string', async () => {
     const userFileId = uuidv4();
-    await createFile({
-      user: userId,
-      file_id: userFileId,
-      filename: 'my-file.txt',
-      filepath: '/uploads/my-file.txt',
-      bytes: 100,
-      type: 'text/plain',
-    });
+    await createFileHelper(userId, userFileId);
 
     const response = await request(app).patch(`/files/${userFileId}`).send({ filename: '' });
 

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -128,6 +128,8 @@ router.get('/config', async (req, res) => {
   }
 });
 
+router.use('/', require('../../../nj/routes/files/files'));
+
 router.delete('/', async (req, res) => {
   try {
     const { files: _files } = req.body;

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -289,6 +289,7 @@ export const fileDownload = (userId: string, fileId: string) =>
  * poll while background HTML extraction is in flight. See PR #12957. */
 export const filePreview = (fileId: string) =>
   `${BASE_URL}/api/files/${encodeURIComponent(fileId)}/preview`;
+export const fileUpdate = (fileId: string) => `${BASE_URL}/api/files/${encodeURIComponent(fileId)}`;
 export const fileConfig = () => `${BASE_URL}/api/files/config`;
 export const agentFiles = (agentId: string) => `${BASE_URL}/api/files/agent/${agentId}`;
 

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -51,3 +51,6 @@ export * from './feedback';
 export * from './parameterSettings';
 /* code-execution sandbox */
 export * from './codeEnvRef';
+
+/* NJ: custom code for ourselves */
+export * from './nj/files';

--- a/packages/data-provider/src/nj/files.ts
+++ b/packages/data-provider/src/nj/files.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const updateFileSchema = z
+  .object({
+    file_id: z.string().min(1),
+    pinned: z.boolean().optional(),
+    filename: z.string().min(1).optional(),
+  })
+  .refine((data) => data.pinned !== undefined || data.filename !== undefined, {
+    message: 'At least one of pinned or filename must be provided',
+  });

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -160,6 +160,7 @@ export type TFile = {
      */
     codeEnvRef?: CodeEnvRef;
   };
+  pinned?: boolean;
   createdAt?: string | Date;
   updatedAt?: string | Date;
 };

--- a/packages/data-schemas/src/schema/file.ts
+++ b/packages/data-schemas/src/schema/file.ts
@@ -144,6 +144,9 @@ const file: Schema<IMongoFile> = new Schema(
       type: String,
       index: true,
     },
+    pinned: {
+      type: Boolean,
+    },
   },
   {
     timestamps: true,

--- a/packages/data-schemas/src/types/file.ts
+++ b/packages/data-schemas/src/types/file.ts
@@ -75,4 +75,5 @@ export interface IMongoFile extends Omit<Document, 'model'> {
   createdAt?: Date;
   updatedAt?: Date;
   tenantId?: string;
+  pinned?: boolean;
 }


### PR DESCRIPTION
We want to be able to pin files (so users can easily reuse them), thus we added a new field to the DB schema: `pinned`.

We also had to add an API method for updating a file (there wasn't one before). It's got thorough tests.

Additionally, we anticipate letting users rename files. Thus the API endpoint also allows for file renames.

These changes were designed with minimizing merge conflicts in mind; the bulk of the logic is NOT in files controlled by upstream. However, it was impossible to full extricate ourselves, so there's some potential for merge conflicts in the future.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1708