### PR TITLE
Remove unused env var

### DIFF
--- a/.github/workflows/render-env.yml
+++ b/.github/workflows/render-env.yml
@@ -49,7 +49,6 @@ jobs:
           set -euo pipefail
 
           export DEBUG=$([[ "${{ inputs.environment }}" == "dev" ]] && echo true || echo false)
-          export DISPLAY_UPDATE_WIDGET=$([[ "${{ inputs.environment }}" == "dev" ]] && echo true || echo false)
           export CONFIG_PATH=$([[ "${{ inputs.deploy_kitchensink }}" == "true" ]] && echo "/app/nj/kitchensink-librechat.yaml" || echo "nj/nj-librechat.yaml")
           export DOMAIN=$([[ "${{ inputs.deploy_kitchensink }}" == "true" ]] && echo "https://kitchensink.ai-assistant.nj.gov" || echo "${{ secrets.DOMAIN }}")
           export ALLOW_SOCIAL_LOGIN=$([[ "${{ inputs.deploy_kitchensink }}" == "true" ]] && echo "false" || echo "true") # disable social login for kitchensink

--- a/README-NJ.md
+++ b/README-NJ.md
@@ -198,8 +198,3 @@ Guardrail configs are managed per-environment through the AWS console. To manage
 
 The connection string for DocumentDB lives in AWS Secrets Manager under the name `ai-assistant/docdb/uri`. If the
 DocumentDB secret is rotated, it must be updated here for LibreChat to maintain connection.
-
-## Updating the New Updates widget
-
-The purpose of this widget is surfacing new updates and changes to the user. Information can be updated in
-`client/src/nj/components/NewUpdatesWidget.tsx`, and the env var `VITE_DISPLAY_UPDATE_WIDGET` must be set to `true`. 

--- a/nj/nj.env.template
+++ b/nj/nj.env.template
@@ -35,12 +35,6 @@ CONSOLE_JSON=true
 CONFIG_PATH=$CONFIG_PATH
 NODE_EXTRA_CA_CERTS="/etc/ssl/certs/ca-certificates.crt"
 
-#==========#
-# Frontend #
-#==========#
-
-VITE_DISPLAY_UPDATE_WIDGET=$DISPLAY_UPDATE_WIDGET
-
 #===================================================#
 #                     Endpoints                     #
 #===================================================#


### PR DESCRIPTION
It stopped being used in 977d804e3d4f4fe2610e8b0df4b19dbd436d00c6, but was never fully removed from the codebase.