### PR TITLE
Setup basic FilesPanel for NJ

### DIFF
--- a/client/src/components/SidePanel/Files/PanelTable.tsx
+++ b/client/src/components/SidePanel/Files/PanelTable.tsx
@@ -36,6 +36,7 @@ import { MyFilesModal } from '~/components/Chat/Input/Files/MyFilesModal';
 import { useFileMapContext, useChatContext } from '~/Providers';
 import { useLocalize, useUpdateFiles } from '~/hooks';
 import { useGetFileConfig } from '~/data-provider';
+import FilesPanel from '~/nj/components/SidePanel/Files/FilesPanel';
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -203,6 +204,10 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
   );
 
   const filenameFilter = table.getColumn('filename')?.getFilterValue() as string;
+
+  // NJ: We're inserting our own version of the panel here, but using PanelTable to get
+  // all the file handling logic that only exists here
+  return <FilesPanel files={data as TFile[]} handleFileClick={handleFileClick} />;
 
   return (
     <div role="region" aria-label={localize('com_files_table')} className="space-y-2">

--- a/client/src/components/SidePanel/Files/__tests__/PanelTable.spec.tsx
+++ b/client/src/components/SidePanel/Files/__tests__/PanelTable.spec.tsx
@@ -110,9 +110,12 @@ function renderTable(data: TFile[]) {
 
 function clickFilenameCell() {
   const cells = screen.getAllByRole('button');
+  const filenameCell = cells[0];
+  /* NJ: Our filename cells are different, so
   const filenameCell = cells.find(
     (cell) => cell.tagName === 'TD' && cell.textContent && !cell.textContent.includes('com_ui_'),
   );
+  */
   if (!filenameCell) {
     throw new Error('Could not find filename cell with role="button" — check mock setup');
   }

--- a/client/src/components/SidePanel/Files/__tests__/PanelTable.spec.tsx
+++ b/client/src/components/SidePanel/Files/__tests__/PanelTable.spec.tsx
@@ -111,7 +111,7 @@ function renderTable(data: TFile[]) {
 function clickFilenameCell() {
   const cells = screen.getAllByRole('button');
   const filenameCell = cells[0];
-  /* NJ: Our filename cells are different, so
+  /* NJ: Our filename cells are different, so find it a different way
   const filenameCell = cells.find(
     (cell) => cell.tagName === 'TD' && cell.textContent && !cell.textContent.includes('com_ui_'),
   );

--- a/client/src/nj/components/SidePanel/Files/FileCell.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileCell.tsx
@@ -1,0 +1,21 @@
+import type { TFile } from 'librechat-data-provider';
+
+/**
+ * Displays a file in `FilesPanel`.
+ */
+export default function FileCell({ file }: { file: TFile }) {
+  const date = file.createdAt
+    ? new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', day: 'numeric' })
+    : '';
+
+  return (
+    <div className="flex gap-3">
+      {/* TODO: Dynamic icon based on mimetype */}
+      <div className="h-10 w-10 flex-shrink-0 rounded bg-gray-200" />
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="truncate text-start text-sm font-medium">{file.filename}</span>
+        <span className="text-token-text-secondary text-start text-xs">{date}</span>
+      </div>
+    </div>
+  );
+}

--- a/client/src/nj/components/SidePanel/Files/FileCell.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileCell.tsx
@@ -4,18 +4,28 @@ import type { TFile } from 'librechat-data-provider';
  * Displays a file in `FilesPanel`.
  */
 export default function FileCell({ file }: { file: TFile }) {
-  const date = file.createdAt
-    ? new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', day: 'numeric' })
-    : '';
-
   return (
     <div className="flex gap-3">
       {/* TODO: Dynamic icon based on mimetype */}
       <div className="h-10 w-10 flex-shrink-0 rounded bg-gray-200" />
       <div className="flex min-w-0 flex-col gap-1">
         <span className="truncate text-start text-sm font-medium">{file.filename}</span>
-        <span className="text-token-text-secondary text-start text-xs">{date}</span>
+        <span className="text-token-text-secondary text-start text-xs">
+          {formatDate(file.createdAt)}
+        </span>
       </div>
     </div>
   );
+}
+
+function formatDate(date?: string | Date): string {
+  if (!date) return '';
+
+  const actualDate = new Date(date);
+  const dateOptions: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric' };
+  if (actualDate.getFullYear() !== new Date().getFullYear()) {
+    dateOptions.year = 'numeric';
+  }
+
+  return actualDate.toLocaleDateString('en-US', dateOptions);
 }

--- a/client/src/nj/components/SidePanel/Files/FilesPanel.tsx
+++ b/client/src/nj/components/SidePanel/Files/FilesPanel.tsx
@@ -10,7 +10,7 @@ import icons from '@uswds/uswds/img/sprite.svg';
  * Our replacement for the built-in LibreChat files panel.
  *
  * Hooks into functionality from parent built-in files panel via constructor params, but otherwise
- * is pretty much a lone
+ * is pretty much does everything else on its own.
  */
 export default function FilesPanel({
   files,

--- a/client/src/nj/components/SidePanel/Files/FilesPanel.tsx
+++ b/client/src/nj/components/SidePanel/Files/FilesPanel.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable i18next/no-literal-string */
+/* ^ We're not worried about i18n for this app ^ */
+
+import { useState } from 'react';
+import type { TFile } from 'librechat-data-provider';
+import FileCell from '~/nj/components/SidePanel/Files/FileCell';
+import icons from '@uswds/uswds/img/sprite.svg';
+
+/**
+ * Our replacement for the built-in LibreChat files panel.
+ *
+ * Hooks into functionality from parent built-in files panel via constructor params, but otherwise
+ * is pretty much a lone
+ */
+export default function FilesPanel({
+  files,
+  handleFileClick,
+}: {
+  files: TFile[];
+  handleFileClick: (file: TFile) => void;
+}) {
+  const [filenameFilter, setFilenameFilter] = useState('');
+
+  const filteredFiles = filenameFilter
+    ? files.filter((file) => file.filename.toLowerCase().includes(filenameFilter.toLowerCase()))
+    : files;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-xl font-bold">Saved files</h1>
+
+      {/* "Search files" filter */}
+      <div className="relative">
+        <svg
+          className="usa-icon--size-3 absolute start-2 top-1/2 -translate-y-1/2 text-text-primary"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <use href={`${icons}#search`} />
+        </svg>
+        <input
+          type="text"
+          placeholder="Search files…"
+          value={filenameFilter}
+          onChange={(event) => setFilenameFilter(event.target.value)}
+          aria-label="Filter files by filename"
+          className="w-full rounded-lg border border-border-light bg-white py-2 pl-9 pr-3 text-sm placeholder:text-text-primary focus-visible:outline-none"
+        />
+      </div>
+
+      {/* Files */}
+      {filteredFiles.map((file: TFile) => (
+        <button key={file.file_id} onClick={() => handleFileClick(file)}>
+          <FileCell file={file} />
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
We've decided to redo the sidebar files panel for our users, so we're customizing it from scratch (sort of).

This first pass sets up basic functionality - it displays the files, lets you click them to add to the current conversation, and has a basic filename filter. All the same things the current sidebar files panel has.

We decided to hook into the existing code for adding files to a current conversation (otherwise we could end up duplicating a lot of logic).

Here's how it looks now:

<img width="570" height="551" alt="Screenshot 2026-05-18 at 11 48 17 AM" src="https://github.com/user-attachments/assets/90131383-3e28-4b66-949f-315865527306" />