### PR TITLE
Separate files into different sections

### DIFF
--- a/client/src/nj/components/SidePanel/Files/FilesPanel.tsx
+++ b/client/src/nj/components/SidePanel/Files/FilesPanel.tsx
@@ -3,8 +3,9 @@
 
 import { useState } from 'react';
 import type { TFile } from 'librechat-data-provider';
-import FileCell from '~/nj/components/SidePanel/Files/FileCell';
 import icons from '@uswds/uswds/img/sprite.svg';
+import { groupFiles } from '~/nj/components/SidePanel/Files/filesLogic';
+import FilesSection from '~/nj/components/SidePanel/Files/FilesSection';
 
 /**
  * Our replacement for the built-in LibreChat files panel.
@@ -24,6 +25,13 @@ export default function FilesPanel({
   const filteredFiles = filenameFilter
     ? files.filter((file) => file.filename.toLowerCase().includes(filenameFilter.toLowerCase()))
     : files;
+
+  const groupedFiles = groupFiles(filteredFiles);
+
+  // Used to determine which section should be the "last" section
+  const hasTodayFiles = groupedFiles.today.length > 0;
+  const hasYesterdayFiles = groupedFiles.yesterday.length > 0;
+  const hasPreviousFiles = groupedFiles.previous.length > 0;
 
   return (
     <div className="flex flex-col gap-4">
@@ -48,12 +56,40 @@ export default function FilesPanel({
         />
       </div>
 
-      {/* Files */}
-      {filteredFiles.map((file: TFile) => (
-        <button key={file.file_id} onClick={() => handleFileClick(file)}>
-          <FileCell file={file} />
-        </button>
-      ))}
+      {/* Pinned */}
+      <FilesSection
+        title="Pinned"
+        files={groupedFiles.pinned}
+        handleFileClick={handleFileClick}
+        showMoreText="Show more pinned files"
+        emptyText="Nothing pinned yet. To pin a file, hover over it and choose pin file from the menu."
+        isLastFileSection={!hasPreviousFiles && !hasYesterdayFiles && !hasTodayFiles}
+      />
+
+      {/* Date-based groups */}
+      <FilesSection
+        title="Today"
+        files={groupedFiles.today}
+        handleFileClick={handleFileClick}
+        showMoreText="Show more files from today"
+        isLastFileSection={!hasPreviousFiles && !hasYesterdayFiles}
+      />
+
+      <FilesSection
+        title="Yesterday"
+        files={groupedFiles.yesterday}
+        handleFileClick={handleFileClick}
+        showMoreText="Show more files from yesterday"
+        isLastFileSection={!hasPreviousFiles}
+      />
+
+      <FilesSection
+        title="Previous"
+        files={groupedFiles.previous}
+        handleFileClick={handleFileClick}
+        showMoreText="Show more files"
+        isLastFileSection={true}
+      />
     </div>
   );
 }

--- a/client/src/nj/components/SidePanel/Files/FilesPanel.tsx
+++ b/client/src/nj/components/SidePanel/Files/FilesPanel.tsx
@@ -63,7 +63,7 @@ export default function FilesPanel({
         handleFileClick={handleFileClick}
         showMoreText="Show more pinned files"
         emptyText="Nothing pinned yet. To pin a file, hover over it and choose pin file from the menu."
-        isLastFileSection={!hasPreviousFiles && !hasYesterdayFiles && !hasTodayFiles}
+        isLastVisibleSection={!hasPreviousFiles && !hasYesterdayFiles && !hasTodayFiles}
       />
 
       {/* Date-based groups */}
@@ -72,7 +72,7 @@ export default function FilesPanel({
         files={groupedFiles.today}
         handleFileClick={handleFileClick}
         showMoreText="Show more files from today"
-        isLastFileSection={!hasPreviousFiles && !hasYesterdayFiles}
+        isLastVisibleSection={!hasPreviousFiles && !hasYesterdayFiles}
       />
 
       <FilesSection
@@ -80,7 +80,7 @@ export default function FilesPanel({
         files={groupedFiles.yesterday}
         handleFileClick={handleFileClick}
         showMoreText="Show more files from yesterday"
-        isLastFileSection={!hasPreviousFiles}
+        isLastVisibleSection={!hasPreviousFiles}
       />
 
       <FilesSection
@@ -88,7 +88,7 @@ export default function FilesPanel({
         files={groupedFiles.previous}
         handleFileClick={handleFileClick}
         showMoreText="Show more files"
-        isLastFileSection={true}
+        isLastVisibleSection={true}
       />
     </div>
   );

--- a/client/src/nj/components/SidePanel/Files/FilesSection.tsx
+++ b/client/src/nj/components/SidePanel/Files/FilesSection.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable i18next/no-literal-string */
+/* ^ We're not worried about i18n for this app ^ */
+
+import { TFile } from 'librechat-data-provider';
+import FileCell from '~/nj/components/SidePanel/Files/FileCell';
+import { useState } from 'react';
+
+const TRUNCATE = 10;
+
+export default function FilesSection({
+  title,
+  files,
+  handleFileClick,
+  showMoreText,
+  emptyText,
+  isLastFileSection,
+}: {
+  title: string;
+  files: TFile[];
+  handleFileClick: (file: TFile) => void;
+  showMoreText: string;
+  emptyText?: string;
+  isLastFileSection?: boolean;
+}) {
+  const [showAll, setShowAll] = useState<boolean>(false);
+
+  const shown = showAll ? files.length : Math.min(files.length, TRUNCATE);
+  const total = files.length;
+  const showingAll = shown === total;
+  const canCollapse = files.length > TRUNCATE;
+
+  const showingText = showingAll ? `Showing ${total}` : `Showing ${shown} of ${total}`;
+  const filesToShow = files.slice(0, shown);
+
+  if (files.length === 0 && !emptyText) return null;
+
+  return (
+    <div className="mb-3 flex flex-col">
+      {/* Header */}
+      <div className="mb-3 flex w-full justify-between">
+        <h2>{title}</h2>
+        {shown > 0 && <div className="text-text-secondary">{showingText}</div>}
+      </div>
+
+      {/* Files (or empty text if none) */}
+      {files.length !== 0 ? (
+        <div className="flex flex-col gap-4 pl-2">
+          {filesToShow.map((file: TFile) => (
+            <button key={file.file_id} onClick={() => handleFileClick(file)}>
+              <FileCell file={file} />
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="pl-2 text-sm">{emptyText}</div>
+      )}
+
+      {/* Show more / show less toggle */}
+      {canCollapse && (
+        <button
+          className="mt-3 font-bold text-jersey-blue underline hover:decoration-2"
+          onClick={() => setShowAll(!showAll)}
+        >
+          {!showingAll ? showMoreText : 'Show less'}
+        </button>
+      )}
+
+      {/* End of files indicator */}
+      {isLastFileSection && showingAll && (
+        <div className="mb-3 mt-3 w-full text-center text-sm text-text-secondary">
+          You&#39;ve reached the end
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/nj/components/SidePanel/Files/FilesSection.tsx
+++ b/client/src/nj/components/SidePanel/Files/FilesSection.tsx
@@ -13,14 +13,14 @@ export default function FilesSection({
   handleFileClick,
   showMoreText,
   emptyText,
-  isLastFileSection,
+  isLastVisibleSection,
 }: {
   title: string;
   files: TFile[];
   handleFileClick: (file: TFile) => void;
   showMoreText: string;
   emptyText?: string;
-  isLastFileSection?: boolean;
+  isLastVisibleSection?: boolean;
 }) {
   const [showAll, setShowAll] = useState<boolean>(false);
 
@@ -66,7 +66,7 @@ export default function FilesSection({
       )}
 
       {/* End of files indicator */}
-      {isLastFileSection && showingAll && (
+      {isLastVisibleSection && showingAll && (
         <div className="mb-3 mt-3 w-full text-center text-sm text-text-secondary">
           You&#39;ve reached the end
         </div>


### PR DESCRIPTION
There's four sections: "pinned", "today", "yesterday", and "preivous."

The pinned section has text when it's empty, so the FilesSection accounts for that.

Initially, we only show 10 files for any given section, which can be expanded if desired. The text for expanding differs for each section. We also allow collapsing back after expanding.

We also put a message at the bottom of all sections to indicate that it's the end. The logic here is a bit complex since it needs to take into account whether the last section is collapsed or not.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1708

# Screenshots

Here's how it looks:

<img width="738" height="1140" alt="Screenshot 2026-05-19 at 10 53 09 AM" src="https://github.com/user-attachments/assets/3b58625b-075b-4a21-aeeb-e0b176c14738" />

Here's how the bottom of the list looks (need to expand):

<img width="662" height="1145" alt="Screenshot 2026-05-19 at 10 53 18 AM" src="https://github.com/user-attachments/assets/7123aecb-b1cf-4e69-b92e-9be1e329b3e2" />