### PR TITLE
Added pin/unpin file feature

### DIFF
--- a/client/src/components/SidePanel/Files/__tests__/PanelTable.spec.tsx
+++ b/client/src/components/SidePanel/Files/__tests__/PanelTable.spec.tsx
@@ -48,6 +48,7 @@ jest.mock('@librechat/client', () => ({
     <thead {...props}>{children}</thead>
   ),
   useToastContext: () => ({ showToast: mockShowToast }),
+  DropdownPopup: () => null,
 }));
 
 jest.mock('~/Providers', () => ({
@@ -72,6 +73,10 @@ jest.mock('~/data-provider', () => ({
 
 jest.mock('~/components/Chat/Input/Files/MyFilesModal', () => ({
   MyFilesModal: () => null,
+}));
+
+jest.mock('~/nj/data-provider/file-mutations', () => ({
+  useUpdateFileMutation: () => ({ mutate: jest.fn(), isPending: false }),
 }));
 
 jest.mock('../PanelFileCell', () => ({ row }: { row: { original: TFile } }) => (

--- a/client/src/nj/components/SidePanel/Files/FileCell.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileCell.tsx
@@ -1,11 +1,26 @@
+import { useState } from 'react';
 import type { TFile } from 'librechat-data-provider';
+import icons from '@uswds/uswds/img/sprite.svg';
+import { cn } from '~/utils';
+import FileOptions from './FileOptions';
 
 /**
  * Displays a file in `FilesPanel`.
  */
-export default function FileCell({ file }: { file: TFile }) {
+export default function FileCell({
+  file,
+  onFileClick,
+}: {
+  file: TFile;
+  onFileClick: (file: TFile) => void;
+}) {
+  const [isPopoverActive, setIsPopoverActive] = useState(false);
+
   return (
-    <div className="flex gap-3">
+    <button
+      className="group flex w-full items-center gap-3 rounded p-2 hover:bg-surface-active-alt"
+      onClick={() => !isPopoverActive && onFileClick(file)}
+    >
       {/* TODO: Dynamic icon based on mimetype */}
       <div className="h-10 w-10 flex-shrink-0 rounded bg-gray-200" />
       <div className="flex min-w-0 flex-col gap-1">
@@ -14,7 +29,31 @@ export default function FileCell({ file }: { file: TFile }) {
           {formatDate(file.createdAt)}
         </span>
       </div>
-    </div>
+      <div className="ml-auto flex items-center">
+        {file.pinned && (
+          <svg
+            className="usa-icon usa-icon--size-3 text-jersey-blue"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <use href={`${icons}#push_pin`} />
+          </svg>
+        )}
+        <div
+          className={cn(
+            'flex',
+            !isPopoverActive &&
+              'pointer-events-none opacity-0 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100',
+          )}
+        >
+          <FileOptions
+            file={file}
+            isPopoverActive={isPopoverActive}
+            setIsPopoverActive={setIsPopoverActive}
+          />
+        </div>
+      </div>
+    </button>
   );
 }
 

--- a/client/src/nj/components/SidePanel/Files/FileOptions.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileOptions.tsx
@@ -1,11 +1,13 @@
 import { useId } from 'react';
 import * as Ariakit from '@ariakit/react';
-import { DropdownPopup } from '@librechat/client';
+import { DropdownPopup, useToastContext } from '@librechat/client';
 import { Ellipsis, Pin } from 'lucide-react';
 import type { MouseEvent } from 'react';
 import type { TFile } from 'librechat-data-provider';
 import { useLocalize } from '~/hooks';
 import { useUpdateFileMutation } from '~/nj/data-provider/file-mutations';
+import { logger } from '~/utils';
+import { NotificationSeverity } from '~/common';
 
 export default function FileOptions({
   file,
@@ -17,8 +19,18 @@ export default function FileOptions({
   setIsPopoverActive: (open: boolean) => void;
 }) {
   const localize = useLocalize();
+  const { showToast } = useToastContext();
   const menuId = useId();
-  const updateMutation = useUpdateFileMutation();
+  const updateMutation = useUpdateFileMutation({
+    onError: (err) => {
+      logger.error('Error pinning file', err);
+      showToast({
+        message: 'Failed to pin file',
+        severity: NotificationSeverity.ERROR,
+        showIcon: true,
+      });
+    },
+  });
 
   const dropdownItems = [
     {

--- a/client/src/nj/components/SidePanel/Files/FileOptions.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileOptions.tsx
@@ -1,0 +1,56 @@
+import { useId } from 'react';
+import * as Ariakit from '@ariakit/react';
+import { DropdownPopup } from '@librechat/client';
+import { Ellipsis, Pin } from 'lucide-react';
+import type { MouseEvent } from 'react';
+import type { TFile } from 'librechat-data-provider';
+import { useLocalize } from '~/hooks';
+import { useUpdateFileMutation } from '~/nj/data-provider/file-mutations';
+
+export default function FileOptions({
+  file,
+  isPopoverActive,
+  setIsPopoverActive,
+}: {
+  file: TFile;
+  isPopoverActive: boolean;
+  setIsPopoverActive: (open: boolean) => void;
+}) {
+  const localize = useLocalize();
+  const menuId = useId();
+  const updateMutation = useUpdateFileMutation();
+
+  const dropdownItems = [
+    {
+      label: file.pinned ? localize('com_ui_unpin') : localize('com_ui_pin'),
+      onClick: () => updateMutation.mutate({ file_id: file.file_id, pinned: !file.pinned }),
+      icon: <Pin className="icon-sm mr-2 text-text-primary" aria-hidden="true" />,
+    },
+  ];
+
+  return (
+    <DropdownPopup
+      portal={true}
+      menuId={menuId}
+      focusLoop={true}
+      className="z-[125]"
+      unmountOnHide={true}
+      isOpen={isPopoverActive}
+      setIsOpen={setIsPopoverActive}
+      trigger={
+        <Ariakit.MenuButton
+          aria-label="File options"
+          aria-expanded={isPopoverActive}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+          onClick={(e: MouseEvent<HTMLButtonElement>) => e.stopPropagation()}
+          onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
+            if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+          }}
+        >
+          <Ellipsis className="icon-md text-text-secondary" aria-hidden={true} />
+        </Ariakit.MenuButton>
+      }
+      items={dropdownItems}
+    />
+  );
+}

--- a/client/src/nj/components/SidePanel/Files/FilesSection.tsx
+++ b/client/src/nj/components/SidePanel/Files/FilesSection.tsx
@@ -44,11 +44,9 @@ export default function FilesSection({
 
       {/* Files (or empty text if none) */}
       {files.length !== 0 ? (
-        <div className="flex flex-col gap-4 pl-2">
+        <div className="flex flex-col">
           {filesToShow.map((file: TFile) => (
-            <button key={file.file_id} onClick={() => handleFileClick(file)}>
-              <FileCell file={file} />
-            </button>
+            <FileCell key={file.file_id} file={file} onFileClick={handleFileClick} />
           ))}
         </div>
       ) : (

--- a/client/src/nj/data-provider/file-mutations.ts
+++ b/client/src/nj/data-provider/file-mutations.ts
@@ -4,11 +4,11 @@ import { dataService, MutationKeys, QueryKeys } from 'librechat-data-provider';
 
 export const useUpdateFileMutation = (
   _options?: t.UpdateFileMutationOptions,
-): UseMutationResult<t.TFile, unknown, t.UpdateFileBody, unknown> => {
+): UseMutationResult<t.TFile, unknown, t.UpdateFileMetadataBody, unknown> => {
   const queryClient = useQueryClient();
   const { onSuccess, onError, ...options } = _options || {};
   return useMutation([MutationKeys.fileUpdate], {
-    mutationFn: (body: t.UpdateFileBody) => dataService.updateFile(body),
+    mutationFn: (body: t.UpdateFileMetadataBody) => dataService.updateFile(body),
     ...options,
     onSuccess: (data, vars, context) => {
       queryClient.setQueryData<t.TFile[] | undefined>([QueryKeys.files], (files) =>

--- a/client/src/nj/data-provider/file-mutations.ts
+++ b/client/src/nj/data-provider/file-mutations.ts
@@ -1,0 +1,23 @@
+import type * as t from 'librechat-data-provider';
+import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query';
+import { dataService, MutationKeys, QueryKeys } from 'librechat-data-provider';
+
+export const useUpdateFileMutation = (
+  _options?: t.UpdateFileMutationOptions,
+): UseMutationResult<t.TFile, unknown, t.UpdateFileBody, unknown> => {
+  const queryClient = useQueryClient();
+  const { onSuccess, onError, ...options } = _options || {};
+  return useMutation([MutationKeys.fileUpdate], {
+    mutationFn: (body: t.UpdateFileBody) => dataService.updateFile(body),
+    ...options,
+    onSuccess: (data, vars, context) => {
+      queryClient.setQueryData<t.TFile[] | undefined>([QueryKeys.files], (files) =>
+        (files ?? []).map((file) => (file.file_id === vars.file_id ? { ...file, ...data } : file)),
+      );
+      onSuccess?.(data, vars, context);
+    },
+    onError: (error, vars, context) => {
+      onError?.(error, vars, context);
+    },
+  });
+};

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -724,7 +724,7 @@ export const deleteFiles = async (payload: {
     data: payload,
   });
 
-export const updateFile = (payload: nj.UpdateFileBody): Promise<f.TFile> =>
+export const updateFile = (payload: nj.UpdateFileMetadataBody): Promise<f.TFile> =>
   request.patch(endpoints.fileUpdate(payload.file_id), payload);
 
 /* Speech */

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -13,6 +13,7 @@ import request from './request';
 import * as s from './schemas';
 import * as r from './roles';
 import * as permissions from './accessPermissions';
+import * as nj from './nj/files';
 
 export function revokeUserKey(name: string): Promise<unknown> {
   return request.delete(endpoints.revokeUserKey(name));
@@ -722,6 +723,9 @@ export const deleteFiles = async (payload: {
   request.deleteWithOptions(endpoints.files(), {
     data: payload,
   });
+
+export const updateFile = (payload: nj.UpdateFileBody): Promise<f.TFile> =>
+  request.patch(endpoints.fileUpdate(payload.file_id), payload);
 
 /* Speech */
 

--- a/packages/data-provider/src/keys.ts
+++ b/packages/data-provider/src/keys.ts
@@ -92,6 +92,7 @@ export enum MutationKeys {
   deleteAgentApiKey = 'deleteAgentApiKey',
   fileUpload = 'fileUpload',
   fileDelete = 'fileDelete',
+  fileUpdate = 'fileUpdate',
   updatePreset = 'updatePreset',
   deletePreset = 'deletePreset',
   loginUser = 'loginUser',

--- a/packages/data-provider/src/nj/files.ts
+++ b/packages/data-provider/src/nj/files.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { TFile } from '../types/files';
 
 export const updateFileSchema = z
   .object({
@@ -9,3 +10,15 @@ export const updateFileSchema = z
   .refine((data) => data.pinned !== undefined || data.filename !== undefined, {
     message: 'At least one of pinned or filename must be provided',
   });
+
+export type UpdateFileBody = {
+  file_id: string;
+  pinned?: boolean;
+  filename?: string;
+};
+
+export type UpdateFileMutationOptions = {
+  onSuccess?: (data: TFile, variables: UpdateFileBody, context?: unknown) => void;
+  onMutate?: (variables: UpdateFileBody) => void | Promise<unknown>;
+  onError?: (error: unknown, variables: UpdateFileBody, context?: unknown) => void;
+};

--- a/packages/data-provider/src/nj/files.ts
+++ b/packages/data-provider/src/nj/files.ts
@@ -11,14 +11,14 @@ export const updateFileSchema = z
     message: 'At least one of pinned or filename must be provided',
   });
 
-export type UpdateFileBody = {
+export type UpdateFileMetadataBody = {
   file_id: string;
   pinned?: boolean;
   filename?: string;
 };
 
 export type UpdateFileMutationOptions = {
-  onSuccess?: (data: TFile, variables: UpdateFileBody, context?: unknown) => void;
-  onMutate?: (variables: UpdateFileBody) => void | Promise<unknown>;
-  onError?: (error: unknown, variables: UpdateFileBody, context?: unknown) => void;
+  onSuccess?: (data: TFile, variables: UpdateFileMetadataBody, context?: unknown) => void;
+  onMutate?: (variables: UpdateFileMetadataBody) => void | Promise<unknown>;
+  onError?: (error: unknown, variables: UpdateFileMetadataBody, context?: unknown) => void;
 };


### PR DESCRIPTION
Now an overflow menu appears on files when you hover over them, and the menu has the option to pin (or unpin) files in the sidebar.

I modeled this after how conversations' popups work (but greatly simplified the code). Part of simplifying the code involved moving the button functionality into FileCell itself.

I also modeled the update after how the rest of the client works (based off `use*Mutation()` functions).

Part of https://github.com/newjersey/innovation-platform-pm/issues/1708

------

Here's video of the feature in action:

https://github.com/user-attachments/assets/0fb33812-d0f8-4cf5-8d68-658fad0ddeb2

