### PR TITLE
Added 'rename file' feature

### DIFF
--- a/client/src/nj/components/SidePanel/Files/FileCell.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileCell.tsx
@@ -1,11 +1,13 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { TFile } from 'librechat-data-provider';
 import icons from '@uswds/uswds/img/sprite.svg';
 import { useUpdateFileMutation } from '~/nj/data-provider/file-mutations';
 import RenameForm from '~/components/Conversations/RenameForm';
 import { useLocalize } from '~/hooks';
-import { cn } from '~/utils';
+import { cn, logger } from '~/utils';
 import FileOptions from './FileOptions';
+import { NotificationSeverity } from '~/common';
+import { useToastContext } from '@librechat/client';
 
 /**
  * Displays a file in `FilesPanel`.
@@ -18,17 +20,35 @@ export default function FileCell({
   onFileClick: (file: TFile) => void;
 }) {
   const localize = useLocalize();
-  const updateMutation = useUpdateFileMutation();
+  const { showToast } = useToastContext();
+  const updateMutation = useUpdateFileMutation({
+    onSuccess: () => {
+      setRenaming(false);
+    },
+    onError: (err) => {
+      logger.error('Error renaming file', err);
+      showToast({
+        message: 'Failed to rename file',
+        severity: NotificationSeverity.ERROR,
+        showIcon: true,
+      });
+    },
+  });
   const [isPopoverActive, setIsPopoverActive] = useState(false);
   const [renaming, setRenaming] = useState(false);
   const [filenameInput, setFilenameInput] = useState(file.filename);
+
+  useEffect(() => {
+    setFilenameInput(file.filename);
+  }, [file.filename]);
 
   const handleRenameSubmit = (newName: string) => {
     const trimmed = newName.trim();
     if (trimmed && trimmed !== file.filename) {
       updateMutation.mutate({ file_id: file.file_id, filename: trimmed });
+    } else {
+      setRenaming(false);
     }
-    setRenaming(false);
   };
 
   const handleRenameCancel = () => {

--- a/client/src/nj/components/SidePanel/Files/FileCell.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileCell.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import type { TFile } from 'librechat-data-provider';
 import icons from '@uswds/uswds/img/sprite.svg';
+import { useUpdateFileMutation } from '~/nj/data-provider/file-mutations';
+import RenameForm from '~/components/Conversations/RenameForm';
+import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 import FileOptions from './FileOptions';
 
@@ -14,21 +17,50 @@ export default function FileCell({
   file: TFile;
   onFileClick: (file: TFile) => void;
 }) {
+  const localize = useLocalize();
+  const updateMutation = useUpdateFileMutation();
   const [isPopoverActive, setIsPopoverActive] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [filenameInput, setFilenameInput] = useState(file.filename);
+
+  const handleRenameSubmit = (newName: string) => {
+    const trimmed = newName.trim();
+    if (trimmed && trimmed !== file.filename) {
+      updateMutation.mutate({ file_id: file.file_id, filename: trimmed });
+    }
+    setRenaming(false);
+  };
+
+  const handleRenameCancel = () => {
+    setFilenameInput(file.filename);
+    setRenaming(false);
+  };
 
   return (
     <button
       className="group flex w-full items-center gap-3 rounded p-2 hover:bg-surface-active-alt"
-      onClick={() => !isPopoverActive && onFileClick(file)}
+      onClick={() => !isPopoverActive && !renaming && onFileClick(file)}
     >
       {/* TODO: Dynamic icon based on mimetype */}
       <div className="h-10 w-10 flex-shrink-0 rounded bg-gray-200" />
-      <div className="flex min-w-0 flex-col gap-1">
-        <span className="truncate text-start text-sm font-medium">{file.filename}</span>
-        <span className="text-token-text-secondary text-start text-xs">
-          {formatDate(file.createdAt)}
-        </span>
-      </div>
+      {renaming ? (
+        <div className="relative h-10 min-w-0 flex-1">
+          <RenameForm
+            titleInput={filenameInput}
+            setTitleInput={setFilenameInput}
+            onSubmit={handleRenameSubmit}
+            onCancel={handleRenameCancel}
+            localize={localize}
+          />
+        </div>
+      ) : (
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="truncate text-start text-sm font-medium">{file.filename}</span>
+          <span className="text-token-text-secondary text-start text-xs">
+            {formatDate(file.createdAt)}
+          </span>
+        </div>
+      )}
       <div className="ml-auto flex items-center">
         {file.pinned && (
           <svg
@@ -50,6 +82,7 @@ export default function FileCell({
             file={file}
             isPopoverActive={isPopoverActive}
             setIsPopoverActive={setIsPopoverActive}
+            onRename={() => setRenaming(true)}
           />
         </div>
       </div>

--- a/client/src/nj/components/SidePanel/Files/FileCell.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileCell.tsx
@@ -59,7 +59,11 @@ export default function FileCell({
   return (
     <button
       className="group flex w-full items-center gap-3 rounded p-2 hover:bg-surface-active-alt"
-      onClick={() => !isPopoverActive && !renaming && onFileClick(file)}
+      onClick={() => {
+        if (!isPopoverActive && !renaming) {
+          onFileClick(file);
+        }
+      }}
     >
       {/* TODO: Dynamic icon based on mimetype */}
       <div className="h-10 w-10 flex-shrink-0 rounded bg-gray-200" />

--- a/client/src/nj/components/SidePanel/Files/FileOptions.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileOptions.tsx
@@ -1,22 +1,24 @@
 import { useId } from 'react';
 import * as Ariakit from '@ariakit/react';
 import { DropdownPopup, useToastContext } from '@librechat/client';
-import { Ellipsis, Pin } from 'lucide-react';
+import { Ellipsis, Pen, Pin } from 'lucide-react';
 import type { MouseEvent } from 'react';
 import type { TFile } from 'librechat-data-provider';
-import { useLocalize } from '~/hooks';
 import { useUpdateFileMutation } from '~/nj/data-provider/file-mutations';
 import { logger } from '~/utils';
 import { NotificationSeverity } from '~/common';
+import { useLocalize } from '~/hooks';
 
 export default function FileOptions({
   file,
   isPopoverActive,
   setIsPopoverActive,
+  onRename,
 }: {
   file: TFile;
   isPopoverActive: boolean;
   setIsPopoverActive: (open: boolean) => void;
+  onRename: () => void;
 }) {
   const localize = useLocalize();
   const { showToast } = useToastContext();
@@ -37,6 +39,11 @@ export default function FileOptions({
       label: file.pinned ? localize('com_ui_unpin') : localize('com_ui_pin'),
       onClick: () => updateMutation.mutate({ file_id: file.file_id, pinned: !file.pinned }),
       icon: <Pin className="icon-sm mr-2 text-text-primary" aria-hidden="true" />,
+    },
+    {
+      label: localize('com_ui_rename'),
+      onClick: onRename,
+      icon: <Pen className="icon-sm mr-2 text-text-primary" aria-hidden="true" />,
     },
   ];
 


### PR DESCRIPTION
Now the files side panel has a "rename" option, which you can use to invoke a rename state (much like how conversation renaming works; in fact, I purposefully used the same component Convo.tsx uses).

Part of https://github.com/newjersey/innovation-platform-pm/issues/1708

Here's a video of it in action:

https://github.com/user-attachments/assets/fdc45c16-1b23-4096-a3ee-f671d538919b