### PR TITLE
Improved CI on pull requests

### DIFF
--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -1,18 +1,16 @@
 name: Backend Unit Tests
 on:
   pull_request:
-    branches:
-      - main
-      - dev
-      - dev-staging
-      - release/*
-      - newjersey # NJ: our primary branch
     paths:
       - 'api/**'
       - 'packages/**'
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   NODE_ENV: CI

--- a/.github/workflows/cache-integration-tests.yml
+++ b/.github/workflows/cache-integration-tests.yml
@@ -2,12 +2,6 @@ name: Cache Integration Tests
 
 on:
   pull_request:
-    branches:
-      - main
-      - dev
-      - dev-staging
-      - release/*
-      - newjersey # NJ: our primary branch
     paths:
       - 'packages/api/src/cache/**'
       - 'packages/api/src/cluster/**'
@@ -18,6 +12,10 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   cache_integration_tests:

--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -2,15 +2,13 @@ name: ESLint Code Quality Checks
 
 on:
   pull_request:
-    branches:
-      - main
-      - dev
-      - dev-staging
-      - release/*
-      - newjersey # NJ: our primary branch
     paths:
       - 'api/**'
       - 'client/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   eslint_checks:

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -2,18 +2,16 @@ name: Frontend Unit Tests
 
 on:
   pull_request:
-    branches:
-      - main
-      - dev
-      - dev-staging
-      - release/*
-      - newjersey # NJ: our primary branch
     paths:
       - 'client/**'
       - 'packages/data-provider/**'
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   NODE_OPTIONS: '--max-old-space-size=${{ secrets.NODE_MAX_OLD_SPACE_SIZE || 6144 }}'

--- a/.github/workflows/nj-e2e-tests.yml
+++ b/.github/workflows/nj-e2e-tests.yml
@@ -27,6 +27,10 @@ on:
         required: false
         default: 'Manual e2e test run'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # A bunch of variables we need, some might get flagged as secrets, but they aren't
 # (they're just config values that we need to run the tests, and don't contain any sensitive info)
 env:


### PR DESCRIPTION
First, I removed the branch filter. That way, stacked PRs still have CI run on them.

Second, I added `concurrency` so that subsequent updates to a PR automatically cancel runs still in progress.
