### PR TITLE
Added env var for fileStrategy

### DIFF
--- a/nj/nj-librechat.yaml
+++ b/nj/nj-librechat.yaml
@@ -10,6 +10,8 @@ version: 1.3.6
 
 # Cache settings: Set to true to enable caching
 cache: true
+
+# We use S3 when deployed, but for local dev, recommend setting `FILE_STRATEGY=local` in .env
 fileStrategy: 's3'
 
 # Custom interface configuration

--- a/packages/data-schemas/src/app/service.ts
+++ b/packages/data-schemas/src/app/service.ts
@@ -85,7 +85,10 @@ export const AppService = async (params?: {
   const summarization = loadSummarizationConfig(config);
   const filteredTools = config.filteredTools;
   const includedTools = config.includedTools;
-  const fileStrategy = (config.fileStrategy ?? configDefaults.fileStrategy) as
+  // NJ: We want to be able to use `local` for local dev, thus an optional env var
+  const fileStrategy = (process.env.FILE_STRATEGY ??
+    config.fileStrategy ??
+    configDefaults.fileStrategy) as
     | FileSources.local
     | FileSources.s3
     | FileSources.firebase


### PR DESCRIPTION
Just a small thing so that we can develop locally without having to try to connect to S3 (or modify our local nj-librechat.yaml).
