### PR TITLE
Added FileIcon next to files in side panel

### DIFF
--- a/client/src/nj/components/SidePanel/Files/FileCell.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileCell.tsx
@@ -8,6 +8,7 @@ import { cn, logger } from '~/utils';
 import FileOptions from './FileOptions';
 import { NotificationSeverity } from '~/common';
 import { useToastContext } from '@librechat/client';
+import FileIcon from '~/nj/components/SidePanel/Files/FileIcon';
 
 /**
  * Displays a file in `FilesPanel`.
@@ -65,8 +66,7 @@ export default function FileCell({
         }
       }}
     >
-      {/* TODO: Dynamic icon based on mimetype */}
-      <div className="h-10 w-10 flex-shrink-0 rounded bg-gray-200" />
+      <FileIcon file={file} />
       {renaming ? (
         <div className="relative h-10 min-w-0 flex-1">
           <RenameForm

--- a/client/src/nj/components/SidePanel/Files/FileIcon.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileIcon.tsx
@@ -1,0 +1,68 @@
+import type { TFile } from 'librechat-data-provider';
+import mime from 'mime';
+import { cn } from '~/utils';
+
+const EXTENSION_SPECIAL_CASES: Record<string, string> = {
+  'text/css': 'css',
+  'text/javascript': 'js',
+  'text/x-c': 'c',
+  'text/x-c++': 'cpp',
+  'text/x-csharp': 'cs',
+  'text/x-go': 'go',
+  'text/x-java': 'java',
+  'text/x-kotlin': 'kt',
+  'text/x-lua': 'lua',
+  'text/markdown': 'md',
+  'text/x-perl': 'pl',
+  'text/x-python': 'py',
+  'text/x-r': 'r',
+  'text/x-ruby': 'rb',
+  'text/x-rust': 'rs',
+  'text/x-scala': 'scala',
+  'text/x-swift': 'swift',
+  'text/x-typescript': 'ts',
+};
+
+function getExtension(mimetype: string): string {
+  // Special cases not covered by automatic finder (or not covered well)
+  if (mimetype in EXTENSION_SPECIAL_CASES) {
+    return EXTENSION_SPECIAL_CASES[mimetype];
+  }
+
+  // @ts-ignore - LibreChat is using the wrong TS specs w/ their version of mime
+  return mime.getExtension(mimetype) || '';
+}
+
+const TYPE_TO_CLASS: Record<string, string> = {
+  application: 'file-icon-application',
+  audio: 'file-icon-audio',
+  image: 'file-icon-image',
+  text: 'file-icon-text',
+  video: 'file-icon-video',
+};
+
+function getClassName(mimetype: string): string {
+  const type = mimetype.split('/')[0];
+  return TYPE_TO_CLASS[type] ?? 'file-icon-default';
+}
+
+/**
+ * Displays an icon stylized for each file type.
+ */
+export default function FileIcon({ file }: { file: TFile }) {
+  const extension = getExtension(file.type);
+  const className = getClassName(file.type);
+  const textSizeClass = extension.length < 4 ? 'text-sm' : 'text-xs';
+
+  return (
+    <div
+      className={cn(
+        'text-md flex h-10 w-10 flex-shrink-0 items-center justify-center rounded',
+        className,
+        textSizeClass,
+      )}
+    >
+      {extension.toLocaleUpperCase('en-US')}
+    </div>
+  );
+}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -3117,3 +3117,34 @@ body {
 .markdown-nj li a {
   font-weight: normal;
 }
+
+/* File icon styles */
+.file-icon-default {
+  color: #782312;
+  background-color: #FFF3EA;
+}
+
+.file-icon-audio {
+  color: #45472F;
+  background-color: #F1F4D7;
+}
+
+.file-icon-application {
+  color: #2F4668;
+  background-color: #ECF1F7;
+}
+
+.file-icon-image {
+  color: #453C7B;
+  background-color: #F1EFF7;
+}
+
+.file-icon-text {
+  color: #4D4438;
+  background-color: #F5F0E6;
+}
+
+.file-icon-video {
+  color: #45472F;
+  background-color: #F1F4D7;
+}


### PR DESCRIPTION
It configures its behavior based on the file's mimetype, changing its color scheme & extension dynamically.

To avoid introducing new dependencies, we're using the existing `mime` library. It's a bit out-of-date, so we hardcode some mimetypes -> extensions.

Unfortunately, one deficiency of FileIcon is not the component itself, but the way files are processed by LibreChat. For example, all images are converted to PNG, which means we don't really see the original mimetype for any images (unless they're already a PNG). We may have to dig in further to fix this later.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1709