### PR TITLE
Added file event logging for PanelTable

### DIFF
--- a/client/src/components/SidePanel/Files/PanelTable.tsx
+++ b/client/src/components/SidePanel/Files/PanelTable.tsx
@@ -37,6 +37,12 @@ import { useFileMapContext, useChatContext } from '~/Providers';
 import { useLocalize, useUpdateFiles } from '~/hooks';
 import { useGetFileConfig } from '~/data-provider';
 import FilesPanel from '~/nj/components/SidePanel/Files/FilesPanel';
+import {
+  logCombinedFileSizeError,
+  logFileCountError,
+  logFileSizeError,
+  logFileTypeError,
+} from '~/nj/analytics/logHelpers';
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -144,6 +150,7 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
       }
 
       if (endpointFileConfig.fileLimit && files.size >= endpointFileConfig.fileLimit) {
+        logFileCountError(files.size);
         showToast({
           message: `${localize('com_ui_attach_error_limit')} ${endpointFileConfig.fileLimit} files (${endpoint})`,
           status: 'error',
@@ -152,6 +159,7 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
       }
 
       if (fileData.bytes >= (endpointFileConfig.fileSizeLimit ?? Number.MAX_SAFE_INTEGER)) {
+        logFileSizeError(fileData);
         showToast({
           message: `${localize('com_ui_attach_error_size')} ${
             (endpointFileConfig.fileSizeLimit ?? 0) / megabyte
@@ -162,6 +170,7 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
       }
 
       if (!defaultFileConfig.checkType(file.type, endpointFileConfig.supportedMimeTypes ?? [])) {
+        logFileTypeError(fileData);
         showToast({
           message: `${localize('com_ui_attach_error_type')} ${file.type} (${endpoint})`,
           status: 'error',
@@ -177,6 +186,7 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
         }
         currentTotalSize -= existing?.size ?? 0;
         if (currentTotalSize + fileData.bytes > endpointFileConfig.totalSizeLimit) {
+          logCombinedFileSizeError(Array.from(files.values()), [fileData]);
           showToast({
             message: `${localize('com_ui_attach_error_total_size')} ${endpointFileConfig.totalSizeLimit / megabyte} MB (${endpoint})`,
             status: 'error',

--- a/client/src/components/SidePanel/Files/__tests__/PanelTable.spec.tsx
+++ b/client/src/components/SidePanel/Files/__tests__/PanelTable.spec.tsx
@@ -6,6 +6,14 @@ import type { ExtendedFile } from '~/common';
 import DataTable from '../PanelTable';
 import { columns } from '../PanelColumns';
 
+const mockLogFileCountError = jest.fn();
+const mockLogCombinedFileSizeError = jest.fn();
+
+jest.mock('~/nj/analytics/logHelpers', () => ({
+  logFileCountError: (...args: unknown[]) => mockLogFileCountError(...args),
+  logCombinedFileSizeError: (...args: unknown[]) => mockLogCombinedFileSizeError(...args),
+}));
+
 const mockShowToast = jest.fn();
 const mockAddFile = jest.fn();
 
@@ -132,6 +140,8 @@ describe('PanelTable handleFileClick', () => {
   beforeEach(() => {
     mockShowToast.mockClear();
     mockAddFile.mockClear();
+    mockLogFileCountError.mockClear();
+    mockLogCombinedFileSizeError.mockClear();
     mockFiles = new Map();
     mockConversation = { endpoint: 'openAI' };
     mockRawFileConfig = {
@@ -184,6 +194,8 @@ describe('PanelTable handleFileClick', () => {
         status: 'error',
       }),
     );
+    expect(mockLogFileCountError).toHaveBeenCalledTimes(1);
+    expect(mockLogFileCountError).toHaveBeenCalledWith(5);
   });
 
   it('blocks attachment when totalSizeLimit would be exceeded', () => {
@@ -204,6 +216,11 @@ describe('PanelTable handleFileClick', () => {
         message: expect.stringContaining('com_ui_attach_error_total_size'),
         status: 'error',
       }),
+    );
+    expect(mockLogCombinedFileSizeError).toHaveBeenCalledTimes(1);
+    expect(mockLogCombinedFileSizeError).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ file_id: 'existing-1' })]),
+      expect.arrayContaining([expect.objectContaining({ file_id: largeFile.file_id })]),
     );
   });
 

--- a/client/src/nj/analytics/logHelpers.ts
+++ b/client/src/nj/analytics/logHelpers.ts
@@ -1,4 +1,5 @@
 import { logEvent } from '~/nj/analytics/logEvent';
+import type { TFile } from 'librechat-data-provider';
 import { ErrorTypes, TMessage } from 'librechat-data-provider';
 import { ExtendedFile } from '~/common';
 
@@ -42,28 +43,35 @@ export function logIfPromptLengthError(error: object) {
   logEvent('submit_prompt_client_error_prompt_length', extraParameters);
 }
 
+function getFileSize(file: ExtendedFile | File | TFile): number {
+  return 'bytes' in file ? file.bytes : file.size;
+}
+
 /** Error when a file type is unhandled. */
-export function logFileTypeError(file: File) {
+export function logFileTypeError(file: File | TFile) {
   logEvent('submit_prompt_client_error_file_type', { object_type: file.type });
 }
 
 /** Error when a single file is too large. */
-export function logFileSizeError(file: File) {
+export function logFileSizeError(file: File | TFile) {
   logEvent('submit_prompt_client_error_file_size', {
     object_type: file.type,
-    object_size: file.size,
+    object_size: getFileSize(file),
   });
 }
 
 /** Error when the combined sizes of all files is too large. */
-export function logCombinedFileSizeError(existingFiles: ExtendedFile[], newFiles: File[]) {
+export function logCombinedFileSizeError(
+  existingFiles: ExtendedFile[],
+  newFiles: File[] | TFile[],
+) {
   const existingFileMetadata = existingFiles.map((file) => ({
     type: file.type ?? '',
-    size: file.size,
+    size: getFileSize(file),
   }));
   const newFileMetadata = newFiles.map((file) => ({
     type: file.type,
-    size: file.size,
+    size: getFileSize(file),
   }));
   const allMetadata = existingFileMetadata.concat(newFileMetadata);
 


### PR DESCRIPTION
This is the UI used when adding existing files to the conversation (via the files side panel). It goes through its own validation and thus needs to call the file error events separately.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1725