### PR TITLE
Enable USE_REDIS_CLUSTER for ECS

### DIFF
--- a/nj/infra/lib/ecs-stack.ts
+++ b/nj/infra/lib/ecs-stack.ts
@@ -215,6 +215,7 @@ export class EcsStack extends cdk.Stack {
 
       // Redis configuration
       USE_REDIS: 'true',
+      USE_REDIS_CLUSTER: 'true', // We're using Elasticache Serverless, which is a cluster
       REDIS_URI: redisUri,
       REDIS_USE_ALTERNATIVE_DNS_LOOKUP: 'true',
 


### PR DESCRIPTION
Elasticache Serverless should be treated like a cluster, not a single instance. By treating it like the latter, we were confusing LibreChat's cache handling.