### PR TITLE
Two polishes for FileIcon

### DIFF
--- a/client/src/nj/components/SidePanel/Files/FileIcon.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileIcon.tsx
@@ -30,7 +30,7 @@ function getExtension(mimetype: string): string {
   }
 
   // @ts-ignore - LibreChat is using the wrong TS specs w/ their version of mime
-  return mime.getExtension(mimetype) || '';
+  return mime.getExtension(mimetype) ?? 'file';
 }
 
 const TYPE_TO_CLASS: Record<string, string> = {
@@ -61,6 +61,7 @@ export default function FileIcon({ file }: { file: TFile }) {
         className,
         textSizeClass,
       )}
+      aria-hidden="true"
     >
       {extension.toLocaleUpperCase('en-US')}
     </div>


### PR DESCRIPTION
- Return "file" as the default (a better default)

- Hide it entirely from screen readers (as it's essentially just an icon).

Part of https://github.com/newjersey/innovation-platform-pm/issues/1709