### PR TITLE
Polished a11y of files side panel

### DIFF
--- a/client/src/nj/components/SidePanel/Files/FileCell.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileCell.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable i18next/no-literal-string */
+/* ^ We're not worried about i18n for this app ^ */
+
 import { useEffect, useState } from 'react';
 import type { TFile } from 'librechat-data-provider';
 import icons from '@uswds/uswds/img/sprite.svg';
@@ -65,6 +68,7 @@ export default function FileCell({
           onFileClick(file);
         }
       }}
+      aria-label={`Add ${file.pinned ? 'pinned' : ''} file "${file.filename}" to current conversation`}
     >
       <FileIcon file={file} />
       {renaming ? (

--- a/client/src/nj/components/SidePanel/Files/FileOptions.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileOptions.tsx
@@ -39,11 +39,13 @@ export default function FileOptions({
       label: file.pinned ? localize('com_ui_unpin') : localize('com_ui_pin'),
       onClick: () => updateMutation.mutate({ file_id: file.file_id, pinned: !file.pinned }),
       icon: <Pin className="icon-sm mr-2 text-text-primary" aria-hidden="true" />,
+      ariaLabel: file.pinned ? `Unpin "${file.filename}"` : `Pin "${file.filename}"`,
     },
     {
       label: localize('com_ui_rename'),
       onClick: onRename,
       icon: <Pen className="icon-sm mr-2 text-text-primary" aria-hidden="true" />,
+      ariaLabel: `Rename "${file.filename}"`,
     },
   ];
 
@@ -58,7 +60,7 @@ export default function FileOptions({
       setIsOpen={setIsPopoverActive}
       trigger={
         <Ariakit.MenuButton
-          aria-label="File options"
+          aria-label={`File menu options for "${file.filename}"`}
           aria-expanded={isPopoverActive}
           className="inline-flex h-7 w-7 items-center justify-center rounded-md p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
           onClick={(e: MouseEvent<HTMLButtonElement>) => e.stopPropagation()}

--- a/client/src/nj/components/SidePanel/Files/FilesSection.tsx
+++ b/client/src/nj/components/SidePanel/Files/FilesSection.tsx
@@ -35,6 +35,7 @@ export default function FilesSection({
   if (files.length === 0 && !emptyText) return null;
 
   const headingId = `files-section-${title.toLowerCase()}`;
+  const listId = `${headingId}-list`;
 
   return (
     <section aria-labelledby={headingId} className="mb-3 flex flex-col">
@@ -48,11 +49,13 @@ export default function FilesSection({
 
       {/* Files (or empty text if none) */}
       {files.length !== 0 ? (
-        <div className="flex flex-col">
+        <ol id={listId} className="flex flex-col">
           {filesToShow.map((file: TFile) => (
-            <FileCell key={file.file_id} file={file} onFileClick={handleFileClick} />
+            <li key={file.file_id}>
+              <FileCell file={file} onFileClick={handleFileClick} />
+            </li>
           ))}
-        </div>
+        </ol>
       ) : (
         <div className="pl-2 text-sm">{emptyText}</div>
       )}
@@ -61,6 +64,8 @@ export default function FilesSection({
       {canCollapse && (
         <button
           className="mt-3 font-bold text-jersey-blue underline hover:decoration-2"
+          aria-expanded={showAll}
+          aria-controls={listId}
           onClick={() => setShowAll(!showAll)}
         >
           {!showingAll ? showMoreText : 'Show less'}


### PR DESCRIPTION
- Added descriptive aria-labels for all clickable elements.

- Switched FilesSection to using <ol> for semantic markup.

- File section expand/collapse toggle now uses aria-expanded & aria-controls for better indication of what it's toggling.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1737