### PR TITLE
enable memory for kitchen sink

### DIFF
--- a/nj/kitchensink-librechat.yaml
+++ b/nj/kitchensink-librechat.yaml
@@ -10,11 +10,10 @@ version: 1.3.6
 
 # Cache settings: Set to true to enable caching
 cache: true
-fileStrategy: "s3"
+fileStrategy: 's3'
 
 # Custom interface configuration
 interface:
-
   customWelcome: 'NJ AI Assistant'
 
   # Disable temporary chats (we need to retain data for OPRA)
@@ -47,12 +46,12 @@ interface:
   runCode: true
   sidePanel: true
   webSearch: true
-  mcpServers: 
+  mcpServers:
     use: true
     create: true
     share: true
     public: true
-  remoteAgents: 
+  remoteAgents:
     use: true
     create: true
     share: true
@@ -61,48 +60,48 @@ interface:
 endpoints:
   bedrock:
     availableRegions:
-      - "us-east-1"
-    titleModel: "us.anthropic.claude-sonnet-4-6"
+      - 'us-east-1'
+    titleModel: 'us.anthropic.claude-sonnet-4-6'
     guardrailConfig:
       # My upstream PR to make guardrail config injectable from env vars has not been merged, so I must hardcode
-      guardrailIdentifier: "cwwc15fplrpc"
-      guardrailVersion: "10"
-      trace: "enabled"
+      guardrailIdentifier: 'cwwc15fplrpc'
+      guardrailVersion: '10'
+      trace: 'enabled'
 
   agents:
     capabilities:
-      - "hide_sequential_outputs"
-      - "programmatic_tools"
-      - "end_after_tools"
-      - "deferred_tools"
-      - "execute_code"
-      - "file_search"
-      - "web_search"
-      - "artifacts"
-      - "actions"
-      - "context"
-      - "tools"
-      - "chain"
-      - "ocr"
+      - 'hide_sequential_outputs'
+      - 'programmatic_tools'
+      - 'end_after_tools'
+      - 'deferred_tools'
+      - 'execute_code'
+      - 'file_search'
+      - 'web_search'
+      - 'artifacts'
+      - 'actions'
+      - 'context'
+      - 'tools'
+      - 'chain'
+      - 'ocr'
 
 # We explicitly spec our models (since we only have a few models and this makes the selector simpler)
 modelSpecs:
   list:
     - name: claude-sonnet-4-6
-      label: "Claude Sonnet 4.6"
+      label: 'Claude Sonnet 4.6'
       default: true
       preset:
-        endpoint: "bedrock"
-        model: "us.anthropic.claude-sonnet-4-6"
-    - name: "Claude Sonnet 4.5"
-      label: "Claude Sonnet 4.5"
+        endpoint: 'bedrock'
+        model: 'us.anthropic.claude-sonnet-4-6'
+    - name: 'Claude Sonnet 4.5'
+      label: 'Claude Sonnet 4.5'
       default: true
       preset:
-        endpoint: "bedrock"
-        model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        endpoint: 'bedrock'
+        model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
 
 ocr:
-  strategy: "document_parser"
+  strategy: 'document_parser'
 
 fileConfig:
   endpoints:
@@ -114,5 +113,6 @@ fileConfig:
 memory:
   tokenLimit: 2000
   agent:
-    provider: "bedrock"
-    model: "us.anthropic.claude-sonnet-4-6"
+    enabled: true
+    provider: 'bedrock'
+    model: 'us.anthropic.claude-sonnet-4-6'


### PR DESCRIPTION
## Description
This PR enables the memory feature for the kitchen sink by setting `memory.agent.enabled` to `true` in the kitchen sink config, `kitchensink-librechat.yaml`.

## Ticket
Refers to [De-bug Memory on Kitchen sink](https://github.com/newjersey/innovation-platform-pm/issues/1727)

## Steps to Test
1. Run the app locally.
2. Update the memory settings in `nj-librechat.yaml` by enabling the memory agent.
```yaml
memory:
   agent: 
      enabled: true
```
3. Tell the app to remember something.
   **- Example:** _I want the app to remember with @memory that I am planning a retirement party for my grandma._
 4. Open the memory panel and confirm the memory is saved.
 5. Start a new chat and ask a question related to the saved memory.
    - **Example:** _What am I planning for my grandma?_
 7. Confirm the response is relevant to the saved memory.
  

<img width="575" height="286" alt="Screenshot 2026-05-26 at 3 38 34 PM" src="https://github.com/user-attachments/assets/a8ddde1d-19e6-442a-8e51-3a6953f4f3c9" />

https://github.com/user-attachments/assets/613f96ff-a183-429e-9962-2938aaeac5ee