### PR TITLE
Added "manage agent" dropdown to builder

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -37,6 +37,7 @@ import AgentSelect from './AgentSelect';
 import AgentFooter from './AgentFooter';
 import ModelPanel from './ModelPanel';
 import { useNavigate } from 'react-router-dom';
+import ManageAgentDropdown from '~/nj/components/Agents/ManageAgentDropdown';
 
 /* Helpers */
 function getUpdateToastMessage(
@@ -546,16 +547,29 @@ export default function AgentPanel() {
 
             {/* NJ: add link to agent marketplace here as well */}
             {showAgentMarketplace && (
-              <button
-                type="button"
-                className="mx-3 mt-1 w-full rounded px-2 py-2 hover:bg-surface-active-alt"
-                onClick={() => navigate('/agents')}
-              >
-                <div className="flex flex-1 items-center truncate">
-                  <LayoutGrid className="mr-2 h-5 w-5 text-text-primary" aria-hidden="true" />
-                  <span className="truncate">{localize('com_agents_marketplace')}</span>
-                </div>
-              </button>
+              <div className="mx-3 mt-1 flex w-full flex-row items-center justify-between">
+                <button
+                  type="button"
+                  className="rounded px-2 py-2 hover:bg-surface-active-alt"
+                  onClick={() => navigate('/agents')}
+                >
+                  <div className="flex flex-1 items-center truncate">
+                    <LayoutGrid className="mr-2 h-5 w-5 text-text-primary" aria-hidden="true" />
+                    <span className="truncate text-sm font-semibold">
+                      {localize('com_agents_marketplace')}
+                    </span>
+                  </div>
+                </button>
+
+                {/* NJ: We moved duplicate / delete to the top of the agent builder */}
+                {agent_id && (
+                  <ManageAgentDropdown
+                    agent={agentQuery.data}
+                    createMutation={create}
+                    setCurrentAgentId={setCurrentAgentId}
+                  />
+                )}
+              </div>
             )}
 
             <hr className="mt-1 w-full border-border-heavy" />

--- a/client/src/nj/components/Agents/ManageAgentDropdown.tsx
+++ b/client/src/nj/components/Agents/ManageAgentDropdown.tsx
@@ -79,12 +79,7 @@ export default function ManageAgentDropdown({
       }
 
       const currentAgent = updatedList.find((agent) => agent.id === conversationAgentId);
-
-      if (currentAgent) {
-        setCurrentAgentId(currentAgent.id);
-      }
-
-      setCurrentAgentId(firstAgent.id);
+      setCurrentAgentId(currentAgent?.id ?? firstAgent.id);
     },
     onError: (error) => {
       console.error(error);

--- a/client/src/nj/components/Agents/ManageAgentDropdown.tsx
+++ b/client/src/nj/components/Agents/ManageAgentDropdown.tsx
@@ -1,0 +1,136 @@
+import * as Ariakit from '@ariakit/react';
+import { CopyPlus, MoreHorizontal, Trash } from 'lucide-react';
+import { DropdownPopup, useToastContext } from '@librechat/client';
+import React from 'react';
+import { useLocalize } from '~/hooks';
+import { Agent } from 'librechat-data-provider';
+import { useDeleteAgentMutation, useDuplicateAgentMutation } from '~/data-provider';
+import { AgentPanelProps, MenuItemProps } from '~/common';
+import { getDefaultAgentFormValues, logger } from '~/utils';
+import { useFormContext } from 'react-hook-form';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import store from '~/store';
+
+/**
+ * Dropdown that lets you duplicate/delete an agent.
+ *
+ * Much of the logic used here is borrowed from the original implementations in AgentFooter (and
+ * child components DuplicateAgent and DeleteButton).
+ */
+export default function ManageAgentDropdown({
+  agent,
+  setCurrentAgentId,
+  createMutation,
+}: Pick<AgentPanelProps, 'setCurrentAgentId' | 'createMutation'> & {
+  agent?: Agent;
+}) {
+  const localize = useLocalize();
+  const { showToast } = useToastContext();
+  const { reset } = useFormContext();
+  const setConversation = useSetRecoilState(store.conversationByIndex(0));
+  const conversationAgentId = useRecoilValue(store.conversationAgentIdByIndex(0));
+
+  const [manageMenuIsOpen, setManageMenuIsOpen] = React.useState(false);
+
+  const duplicateAgent = useDuplicateAgentMutation({
+    onSuccess: () => {
+      showToast({
+        message: localize('com_ui_agent_duplicated'),
+        status: 'success',
+      });
+    },
+    onError: (error) => {
+      console.error(error);
+      showToast({
+        message: localize('com_ui_agent_duplicate_error'),
+        status: 'error',
+      });
+    },
+  });
+
+  const deleteAgent = useDeleteAgentMutation({
+    onSuccess: (_, vars, context) => {
+      const updatedList = context as Agent[] | undefined;
+      if (!updatedList) {
+        return;
+      }
+
+      showToast({
+        message: localize('com_ui_agent_deleted'),
+        status: 'success',
+      });
+
+      if (createMutation.data?.id ?? '') {
+        logger.log('agents', 'resetting createMutation');
+        createMutation.reset();
+      }
+
+      const firstAgent = updatedList[0] as Agent | undefined;
+      if (!firstAgent) {
+        setCurrentAgentId(undefined);
+        reset(getDefaultAgentFormValues());
+        setConversation((prev) => (prev ? { ...prev, agent_id: '' } : prev));
+        return;
+      }
+
+      if (vars.agent_id === conversationAgentId) {
+        setConversation((prev) => (prev ? { ...prev, model: '', agent_id: firstAgent.id } : prev));
+        return;
+      }
+
+      const currentAgent = updatedList.find((agent) => agent.id === conversationAgentId);
+
+      if (currentAgent) {
+        setCurrentAgentId(currentAgent.id);
+      }
+
+      setCurrentAgentId(firstAgent.id);
+    },
+    onError: (error) => {
+      console.error(error);
+      showToast({
+        message: localize('com_ui_agent_delete_error'),
+        status: 'error',
+      });
+    },
+  });
+
+  const dropdownItems: MenuItemProps[] = [
+    {
+      label: localize('com_ui_duplicate'),
+      onClick: () => {
+        if (agent?.id) {
+          duplicateAgent.mutate({ agent_id: agent.id });
+        }
+      },
+      icon: <CopyPlus className="size-4" />,
+    },
+    {
+      label: localize('com_ui_delete'),
+      onClick: () => {
+        if (agent?.id) {
+          deleteAgent.mutate({ agent_id: agent.id });
+        }
+      },
+      icon: <Trash className="size-4 text-red-500" />,
+    },
+  ];
+
+  return (
+    <DropdownPopup
+      menuId="manage-agent-menu"
+      isOpen={manageMenuIsOpen}
+      setIsOpen={setManageMenuIsOpen}
+      trigger={
+        <Ariakit.MenuButton
+          aria-label={`Manage agent "${agent?.name}"`}
+          className="flex items-center gap-1 rounded px-2 py-2 text-sm transition-colors hover:bg-surface-active-alt"
+        >
+          <MoreHorizontal className="h-4 w-4 text-text-secondary" aria-hidden="true" />
+          <span className="text-sm font-semibold">{localize('com_ui_manage')}</span>
+        </Ariakit.MenuButton>
+      }
+      items={dropdownItems}
+    />
+  );
+}


### PR DESCRIPTION
Previously, we removed the duplicate/delete agent buttons. Now we're reproducing their functionality in a "manage" dropdown.

All of the nitty gritty logic in ManageAgentDropdown is duplicated from the original LibreChat implementations.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1719

-----

Here's what it looks like:

<img width="620" height="497" alt="Screenshot 2026-05-27 at 2 45 13 PM" src="https://github.com/user-attachments/assets/1adfd17d-a912-464e-aedc-cd0d29cedcf0" />
