### PR TITLE
Don't mark warnings as errors in ESLint CI

### DIFF
--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -61,7 +61,6 @@ jobs:
           # Run ESLint
           npx eslint --no-error-on-unmatched-pattern \
             --config eslint.config.mjs \
-            --max-warnings=0 \
             -- "${CHANGED_FILES[@]}"
 
       # Run Prettier --check on the same set of changed files to catch


### PR DESCRIPTION
This is a recent CI change, but it messes with us (especially since we sometimes leave vars unused for easier merge conflict resolution).