### PR TITLE
Hide agent builder header when in subpanel

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -490,16 +490,18 @@ export default function AgentPanel() {
         aria-label="Agent configuration form"
       >
         <div className="flex-1">
-          <AgentBuilderHeader
-            agent_id={agent_id}
-            onClickCreateNew={() => {
-              reset(getDefaultAgentFormValues());
-              setCurrentAgentId(undefined);
-            }}
-            agentQuery={agentQuery}
-            setCurrentAgentId={setCurrentAgentId}
-            createMutation={create}
-          />
+          {activePanel === Panel.builder && (
+            <AgentBuilderHeader
+              agent_id={agent_id}
+              onClickCreateNew={() => {
+                reset(getDefaultAgentFormValues());
+                setCurrentAgentId(undefined);
+              }}
+              agentQuery={agentQuery}
+              setCurrentAgentId={setCurrentAgentId}
+              createMutation={create}
+            />
+          )}
 
           {/* NJ: We use our own custom agent builder header (above)
           <div className="flex w-full flex-wrap gap-2">


### PR DESCRIPTION
Subpanels are things like "advanced settings" and "version history."

Part of https://github.com/newjersey/innovation-platform-pm/issues/1719

------

Before:

<img width="622" height="519" alt="Screenshot 2026-05-27 at 2 42 00 PM" src="https://github.com/user-attachments/assets/c6d032db-00c3-4031-ac32-79b8d46baaba" />

After:

<img width="623" height="543" alt="Screenshot 2026-05-27 at 2 41 43 PM" src="https://github.com/user-attachments/assets/cfadb305-d406-4ab9-be8b-9b6ba0b5b7a9" />