### PR TITLE
debugging kitchensink redploy failure

### DIFF
--- a/.github/workflows/nj-kitchensink-build.yml
+++ b/.github/workflows/nj-kitchensink-build.yml
@@ -53,5 +53,5 @@ jobs:
         run: |
           aws ecs update-service \
             --cluster "${{ secrets.KITCHENSINK_CLUSTER_NAME }}" \
-            --service "${{ secrets.KITCHENSINK_SERVICE_NAME }}"" \ 
+            --service "${{ secrets.KITCHENSINK_SERVICE_NAME }}" \ 
             --force-new-deployment


### PR DESCRIPTION
## Description 
This PR is an _attempt_ to figure out why the `Redeploy kitchensink from latest` step is failing.

## Ticket 
Refers to [Fix: Kitchen Sink Auto-Deployment Issue](https://github.com/newjersey/innovation-platform-pm/issues/1749)