### PR TITLE
Fix kitchensink deployment failure

### DIFF
--- a/.github/workflows/nj-kitchensink-build.yml
+++ b/.github/workflows/nj-kitchensink-build.yml
@@ -53,5 +53,5 @@ jobs:
         run: |
           aws ecs update-service \
             --cluster "${{ secrets.KITCHENSINK_CLUSTER_NAME }}" \
-            --service "${{ secrets.KITCHENSINK_SERVICE_NAME }}" \ 
+            --service "${{ secrets.KITCHENSINK_SERVICE_NAME }}" \
             --force-new-deployment


### PR DESCRIPTION
This PR is an attempt to figure out why the Redeploy kitchensink from latest step is failing (and fix trailing space).