### PR TITLE
Customized FileSearch UI

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -34,7 +34,6 @@ import Instructions from './Instructions';
 import AgentAvatar from './AgentAvatar';
 import FileContext from './FileContext';
 import SearchForm from './Search/Form';
-import FileSearch from './FileSearch';
 import Artifacts from './Artifacts';
 import AgentTool from './AgentTool';
 import CodeForm from './Code/Form';
@@ -43,6 +42,7 @@ import { useRecoilValue } from 'recoil';
 import store from '~/store';
 import { X } from 'lucide-react';
 import TipComponent from '~/nj/components/TipComponent';
+import FileSearch from '~/nj/components/Agents/FileSearch';
 
 const sectionLabelClass = 'text-sm font-semibold';
 const labelClass = 'mb-2 text-token-text-primary block text-sm font-semibold';
@@ -236,7 +236,7 @@ export default function AgentConfig() {
    * Make sure to check that the LibreChat implementation hasn't drifted too far functionality-wise!
    */
   return (
-    <div className="mb-2 h-auto pt-3">
+    <div className="h-auto pt-3">
       {/* Identity */}
       <div className="mx-3 pb-3">
         <h3 className={sectionLabelClass}>Identity</h3>
@@ -346,15 +346,7 @@ export default function AgentConfig() {
       )}
 
       {/* File search */}
-      {fileSearchEnabled && (
-        <>
-          <hr className="mb-4 border-border-heavy" />
-
-          <div className="mx-3">
-            <FileSearch agent_id={agent_id} files={knowledge_files} />
-          </div>
-        </>
-      )}
+      {fileSearchEnabled && <FileSearch agent_id={agent_id} files={knowledge_files} />}
     </div>
   );
 

--- a/client/src/components/SidePanel/Agents/FileSearch.tsx
+++ b/client/src/components/SidePanel/Agents/FileSearch.tsx
@@ -1,7 +1,4 @@
-/* eslint-disable i18next/no-literal-string */
-/* ^ We're not worried about i18n for this app ^ */
-
-import React, { memo, useMemo, useRef, useState } from 'react';
+import { memo, useMemo, useRef, useState } from 'react';
 import { Folder } from 'lucide-react';
 import * as Ariakit from '@ariakit/react';
 import { useFormContext } from 'react-hook-form';
@@ -128,21 +125,12 @@ function FileSearch({
 
   return (
     <div className="w-full">
-      {/* NJ: Customize how we explain the File Search feature
       <div className="mb-1.5 flex items-center gap-2">
         <span>
           <label className="text-token-text-primary block text-sm font-medium">
             {localize('com_assistants_file_search')}
           </label>
         </span>
-      </div>
-      */}
-      <div className="pb-1">
-        <h3 className="text-sm font-semibold">{localize('com_assistants_file_search')}</h3>
-        <p className="mt-1 text-sm text-text-secondary">
-          Upload any documents you want the agent to search through — like policy documents,
-          research papers, and other work files.
-        </p>
       </div>
       <FileSearchCheckbox />
       <div className="flex flex-col gap-3">

--- a/client/src/nj/components/Agents/AddFilesButton.tsx
+++ b/client/src/nj/components/Agents/AddFilesButton.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable i18next/no-literal-string */
+/* ^ We're not worried about i18n for this app ^ */
+
+import { Plus } from 'lucide-react';
+import React from 'react';
+
+/**
+ * Button to add files to file context / file search.
+ *
+ * It has a different empty state look.
+ */
+export default function AddFilesButton({
+  hasFiles,
+  onClick,
+  emptyMessage,
+}: {
+  hasFiles: boolean;
+  onClick: () => void;
+  emptyMessage: string;
+}) {
+  return (
+    <>
+      {hasFiles ? (
+        <button type="button" className="btn btn-neutral" onClick={onClick}>
+          <div className="flex w-full items-center gap-1 text-sm font-semibold text-jersey-blue">
+            <Plus aria-hidden="true" size={18} />
+            Add files
+          </div>
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="flex w-full flex-col items-center justify-center rounded border-2 border-dashed border-border-medium bg-surface-active-alt px-2 py-4"
+          onClick={onClick}
+        >
+          <p className="text-sm font-semibold text-text-primary">Click to upload files here</p>
+          <p className="text-xs text-text-secondary">{emptyMessage}</p>
+        </button>
+      )}
+    </>
+  );
+}

--- a/client/src/nj/components/Agents/FileSearch.tsx
+++ b/client/src/nj/components/Agents/FileSearch.tsx
@@ -1,0 +1,126 @@
+/* eslint-disable i18next/no-literal-string */
+/* ^ We're not worried about i18n for this app ^ */
+
+import React, { useMemo, useRef, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { AgentCapabilities, EModelEndpoint, EToolResources } from 'librechat-data-provider';
+import type { AgentForm, ExtendedFile } from '~/common';
+import { useFileHandlingNoChatContext } from '~/hooks/Files/useFileHandling';
+import { useAgentFileConfig, useLazyEffect, useLocalize } from '~/hooks';
+import FileRow from '~/components/Chat/Input/Files/FileRow';
+import FileSearchCheckbox from '~/components/SidePanel/Agents/FileSearchCheckbox';
+import AddFilesButton from '~/nj/components/Agents/AddFilesButton';
+
+/**
+ * New Jersey's customized FileSearch UI (based on LibreChat's `FileSearch.tsx`).
+ *
+ * I've taken care to simplify it, given that we don't have things like Sharepoint integration planned.
+ */
+export default function FileSearch({
+  agent_id,
+  files: _files,
+}: {
+  agent_id: string;
+  files?: [string, ExtendedFile][];
+}) {
+  const localize = useLocalize();
+  const { watch } = useFormContext<AgentForm>();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [files, setFiles] = useState<Map<string, ExtendedFile>>(new Map());
+  const fileHandlingState = useMemo(() => ({ files, setFiles, conversation: null }), [files]);
+  const { endpointFileConfig, providerValue, endpointType } = useAgentFileConfig();
+  const endpointOverride = providerValue || EModelEndpoint.agents;
+
+  const { handleFileChange } = useFileHandlingNoChatContext(
+    {
+      additionalMetadata: { agent_id, tool_resource: EToolResources.file_search },
+      endpointOverride,
+      endpointTypeOverride: endpointType,
+      fileSetter: setFiles,
+    },
+    fileHandlingState,
+  );
+
+  useLazyEffect(
+    () => {
+      if (_files) {
+        setFiles(new Map(_files));
+      }
+    },
+    [_files],
+    750,
+  );
+
+  const fileSearchChecked = watch(AgentCapabilities.file_search);
+  const isUploadDisabled = endpointFileConfig?.disabled ?? false;
+
+  if (isUploadDisabled) {
+    return null;
+  }
+
+  const handleButtonClick = () => {
+    // necessary to reset the input
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <div className="w-full">
+      <hr className="mb-2 border-border-heavy" />
+
+      {/* Header & explanation */}
+      <div className="mx-3 mb-3">
+        <h3 className="text-sm font-semibold">{localize('com_assistants_file_search')}</h3>
+        <p className="mt-1 text-sm text-text-secondary">
+          Upload any documents you want the agent to search through — like policy documents,
+          research papers, and other work files.
+        </p>
+        <FileSearchCheckbox />
+      </div>
+
+      <hr className="border-border-heavy" />
+
+      {fileSearchChecked && (
+        <div className="flex flex-col gap-3 bg-presentation px-3 pb-4 pt-4">
+          {/* File Search (RAG API) Files */}
+          <FileRow
+            files={files}
+            setFiles={setFiles}
+            agent_id={agent_id}
+            tool_resource={EToolResources.file_search}
+            Wrapper={({ children }) => <div className="flex flex-wrap gap-2">{children}</div>}
+          />
+
+          {/* File upload button */}
+          {agent_id && (
+            <div>
+              <AddFilesButton
+                hasFiles={files.size !== 0}
+                onClick={handleButtonClick}
+                emptyMessage="Documents, code or images up to 15MB per file"
+              />
+
+              <input
+                multiple={true}
+                type="file"
+                style={{ display: 'none' }}
+                tabIndex={-1}
+                ref={fileInputRef}
+                onChange={handleFileChange}
+              />
+            </div>
+          )}
+
+          {/* Disabled Message */}
+          {!agent_id && (
+            <div className="text-center text-sm text-text-secondary">
+              {localize('com_agents_file_search_disabled')}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
I decided there was enough customization going on to justify splitting the main component off (while still maintaining the logic from the original).

The new customizations involve:

- More description of how the feature works.
- New state management (not showing more than necessary at any given time).
- Custom "add files button", which has a special empty state.

I also removed the customizations I'd previously done to the OG FileSearch.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1719

-----

Here's a video of it in action:

https://github.com/user-attachments/assets/95113851-45a3-464c-acde-de2504dd1e79
