### PR TITLE
Customized FileContext UI

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -32,7 +32,6 @@ import { useListSkillsQuery, useGetAgentFiles } from '~/data-provider';
 import { icons } from '~/hooks/Endpoint/Icons';
 import Instructions from './Instructions';
 import AgentAvatar from './AgentAvatar';
-import FileContext from './FileContext';
 import SearchForm from './Search/Form';
 import Artifacts from './Artifacts';
 import AgentTool from './AgentTool';
@@ -42,6 +41,7 @@ import { useRecoilValue } from 'recoil';
 import store from '~/store';
 import { X } from 'lucide-react';
 import TipComponent from '~/nj/components/TipComponent';
+import FileContext from '~/nj/components/Agents/FileContext';
 import FileSearch from '~/nj/components/Agents/FileSearch';
 
 const sectionLabelClass = 'text-sm font-semibold';
@@ -336,14 +336,8 @@ export default function AgentConfig() {
         stateKey="showAgentComplexBanner"
       />
 
-      <hr className="mb-4 border-border-heavy" />
-
       {/* File context */}
-      {contextEnabled && (
-        <div className="mx-3 mb-3">
-          <FileContext agent_id={agent_id} files={context_files} />
-        </div>
-      )}
+      {contextEnabled && <FileContext agent_id={agent_id} files={context_files} />}
 
       {/* File search */}
       {fileSearchEnabled && <FileSearch agent_id={agent_id} files={knowledge_files} />}

--- a/client/src/components/SidePanel/Agents/FileContext.tsx
+++ b/client/src/components/SidePanel/Agents/FileContext.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable i18next/no-literal-string */
-/* ^ We're not worried about i18n for this app ^ */
-
 import { memo, useMemo, useRef, useState } from 'react';
 import { Folder } from 'lucide-react';
 import * as Ariakit from '@ariakit/react';
@@ -112,7 +109,6 @@ function FileContext({
   );
   return (
     <div className="w-full">
-      {/* NJ: Customize how we explain the File Context feature
       <HoverCard openDelay={50}>
         <div className="mb-2 flex items-center gap-2">
           <HoverCardTrigger asChild>
@@ -134,13 +130,6 @@ function FileContext({
           </HoverCardPortal>
         </div>
       </HoverCard>
-      */}
-      <div className="pb-3">
-        <h3 className="text-sm font-semibold">{localize('com_agents_file_context_label')}</h3>
-        <p className="mt-1 text-sm text-text-secondary">
-          Upload reference materials, examples, templates, or any other relevant documents.
-        </p>
-      </div>
       <div className="flex flex-col gap-3">
         {/* File Context Files */}
         <FileRow

--- a/client/src/nj/components/Agents/FileContext.tsx
+++ b/client/src/nj/components/Agents/FileContext.tsx
@@ -1,0 +1,119 @@
+/* eslint-disable i18next/no-literal-string */
+/* ^ We're not worried about i18n for this app ^ */
+
+import React, { useMemo, useRef, useState } from 'react';
+import { EModelEndpoint, EToolResources } from 'librechat-data-provider';
+import type { ExtendedFile } from '~/common';
+import { useFileHandlingNoChatContext } from '~/hooks/Files/useFileHandling';
+import { useAgentFileConfig, useLazyEffect, useLocalize } from '~/hooks';
+import FileRow from '~/components/Chat/Input/Files/FileRow';
+import AddFilesButton from '~/nj/components/Agents/AddFilesButton';
+
+/**
+ * New Jersey's customized FileContext UI (based on LibreChat's `FileContext.tsx`).
+ *
+ * I've taken care to simplify it, given that we don't have things like Sharepoint integration planned.
+ */
+export default function FileContext({
+  agent_id,
+  files: _files,
+}: {
+  agent_id: string;
+  files?: [string, ExtendedFile][];
+}) {
+  const localize = useLocalize();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [files, setFiles] = useState<Map<string, ExtendedFile>>(new Map());
+  const fileHandlingState = useMemo(() => ({ files, setFiles, conversation: null }), [files]);
+  const { endpointFileConfig, providerValue, endpointType } = useAgentFileConfig();
+  const endpointOverride = providerValue || EModelEndpoint.agents;
+
+  const { handleFileChange } = useFileHandlingNoChatContext(
+    {
+      additionalMetadata: { agent_id, tool_resource: EToolResources.context },
+      endpointOverride,
+      endpointTypeOverride: endpointType,
+      fileSetter: setFiles,
+    },
+    fileHandlingState,
+  );
+
+  useLazyEffect(
+    () => {
+      if (_files) {
+        setFiles(new Map(_files));
+      }
+    },
+    [_files],
+    750,
+  );
+
+  const isUploadDisabled = endpointFileConfig?.disabled ?? false;
+
+  if (isUploadDisabled) {
+    return null;
+  }
+
+  const handleLocalFileClick = () => {
+    // necessary to reset the input
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <div className="w-full">
+      <hr className="mb-2 border-border-heavy" />
+
+      {/* Header & explanation */}
+      <div className="mx-3 mb-3">
+        <h3 className="text-sm font-semibold">{localize('com_agents_file_context_label')}</h3>
+        <p className="mt-1 text-sm text-text-secondary">
+          Upload reference materials, examples, templates, or any other relevant instruction
+          documents.
+        </p>
+      </div>
+
+      <hr className="border-border-heavy" />
+
+      <div className="flex flex-col gap-3 bg-presentation px-3 pb-4 pt-4">
+        {/* File Search (RAG API) Files */}
+        <FileRow
+          files={files}
+          setFiles={setFiles}
+          agent_id={agent_id}
+          tool_resource={EToolResources.file_search}
+          Wrapper={({ children }) => <div className="flex flex-wrap gap-2">{children}</div>}
+        />
+
+        {/* File upload button */}
+        {agent_id && (
+          <div>
+            <AddFilesButton
+              hasFiles={files.size !== 0}
+              onClick={handleLocalFileClick}
+              emptyMessage="Documents or code up to 15MB per file"
+            />
+
+            <input
+              multiple={true}
+              type="file"
+              style={{ display: 'none' }}
+              tabIndex={-1}
+              ref={fileInputRef}
+              onChange={handleFileChange}
+            />
+          </div>
+        )}
+
+        {/* Disabled Message */}
+        {!agent_id && (
+          <div className="text-center text-sm text-text-secondary">
+            {localize('com_agents_file_search_disabled')}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/nj/components/Agents/FileSearch.tsx
+++ b/client/src/nj/components/Agents/FileSearch.tsx
@@ -99,7 +99,7 @@ export default function FileSearch({
               <AddFilesButton
                 hasFiles={files.size !== 0}
                 onClick={handleButtonClick}
-                emptyMessage="Documents, code or images up to 15MB per file"
+                emptyMessage="PDFs, Word docs, or Spreadsheets up to 15MB per file"
               />
 
               <input


### PR DESCRIPTION
I decided there was enough customization going on to justify splitting the main component off (while still maintaining the logic from the original).

The new customizations involve:

- More description of how the feature works.
- New state management (not showing more than necessary at any given time).
- Custom "add files button", which has a special empty state.

I also removed the customizations I'd previously done to the OG FileContext.

(Note that this is nearly a carbon copy of what I did for FileSearch, because the two components have the same basic form and structure.)

Part of https://github.com/newjersey/innovation-platform-pm/issues/1719

-----

Here's a video of it in action:

https://github.com/user-attachments/assets/3df8e1ed-f1b6-4803-9875-70236880f182


