### PR TITLE
Improved styling on TipComponent

### DIFF
--- a/client/src/nj/components/TipComponent.tsx
+++ b/client/src/nj/components/TipComponent.tsx
@@ -30,17 +30,26 @@ export default function TipComponent({
     <div className="mx-3 mb-4 rounded-lg border border-border-light bg-surface-secondary p-3">
       <div className="flex items-start gap-2">
         <svg
-          className="usa-icon usa-icon--size-2 mt-0.5 flex-shrink-0 text-jersey-blue"
+          className="usa-icon tip-component-icon mt-0.5 flex-shrink-0"
           aria-hidden="true"
           focusable="false"
           role="img"
         >
-          <use href={`${uswdsIcons}#lightbulb_outline`} />
+          <defs>
+            <linearGradient id="tipIconGradient" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stopColor="#7EC8E3" />
+              <stop offset="100%" stopColor="#1A6FA8" />
+            </linearGradient>
+            <mask id="tipIconMask">
+              <use
+                href={`${uswdsIcons}#lightbulb_outline`}
+                style={{ fill: 'white', color: 'white' }}
+              />
+            </mask>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#tipIconGradient)" mask="url(#tipIconMask)" />
         </svg>
-        <div className="flex-grow">
-          <p className="text-sm font-medium">{title}</p>
-          <p className="mt-1 text-sm text-text-secondary">{description}</p>
-        </div>
+        <p className="flex-grow text-sm font-medium">{title}</p>
         <button
           type="button"
           onClick={() => setShowComplexBanner(false)}
@@ -50,6 +59,7 @@ export default function TipComponent({
           <X className="h-4 w-4" aria-hidden />
         </button>
       </div>
+      <p className="mt-2 text-sm text-text-secondary">{description}</p>
     </div>
   );
 }

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -3148,3 +3148,9 @@ body {
   color: #45472F;
   background-color: #F1F4D7;
 }
+
+.tip-component-icon {
+  height: 1.25rem;
+  width: 1.25rem;
+  background: #E8F5FF;
+}


### PR DESCRIPTION
- The icon is now larger and has a gradient for the SVG

- The description text now flows underneath the icon & dismiss button (instead of aligning with the title).

Part of https://github.com/newjersey/innovation-platform-pm/issues/1719

------

Before:

<img width="442" height="108" alt="Screenshot 2026-05-28 at 3 46 04 PM" src="https://github.com/user-attachments/assets/cbced91c-d16d-4ca3-a70e-fe6b442dc66c" />

After:

<img width="445" height="118" alt="Screenshot 2026-05-28 at 3 45 51 PM" src="https://github.com/user-attachments/assets/b2b65994-053e-40a6-9ea3-b6acb9697774" />
