### PR TITLE
Fixed hover instruction popup location

### DIFF
--- a/client/src/components/SidePanel/Agents/Instructions.tsx
+++ b/client/src/components/SidePanel/Agents/Instructions.tsx
@@ -63,15 +63,15 @@ export default function Instructions() {
           {localize('com_ui_instructions')}
         </label>
         */}
+        <label
+          className="text-token-text-primary block text-sm font-semibold"
+          htmlFor="instructions"
+        >
+          Give your agent a task
+        </label>
         <HoverCard openDelay={50}>
           <HoverCardTrigger asChild>
-            <span className="flex items-center gap-2">
-              <label
-                className="text-token-text-primary block text-sm font-semibold"
-                htmlFor="instructions"
-              >
-                Give your agent a task
-              </label>
+            <span className="ml-2">
               <CircleHelpIcon className="h-4 w-4 text-text-tertiary" />
             </span>
           </HoverCardTrigger>


### PR DESCRIPTION
It was opening too far to the left because it was spanning the whole label. Now it's focused on just the icon, which will properly center it (and keeps it from being too far left).

Part of https://github.com/newjersey/innovation-platform-pm/issues/1719

-----

Before:

<img width="523" height="280" alt="Screenshot 2026-05-28 at 3 58 34 PM" src="https://github.com/user-attachments/assets/2e90aa90-ee39-4b7a-9811-b200e65ebac0" />

After:

<img width="510" height="286" alt="Screenshot 2026-05-28 at 3 58 26 PM" src="https://github.com/user-attachments/assets/63a396f1-bfa3-4a32-944c-39aedd589820" />
