### PR TITLE
Fix backgrounds on agent builder

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -249,9 +249,9 @@ export default function AgentConfig() {
         </p>
       </div>
 
-      <hr className="mb-4 border-border-heavy" />
+      <hr className="border-border-heavy" />
 
-      <div className="mx-3 mb-4">
+      <div className="bg-surface-tertiary-alt px-3 pb-3 pt-4">
         <label className={labelClass} htmlFor="name">
           Agent Name
           <span className="ml-1 text-red-500">*</span>
@@ -285,7 +285,7 @@ export default function AgentConfig() {
         />
       </div>
 
-      <div className="mx-3 mb-4">
+      <div className="bg-surface-tertiary-alt px-3 pb-4">
         <label className={labelClass} htmlFor="description">
           Description
         </label>
@@ -328,9 +328,9 @@ export default function AgentConfig() {
         </p>
       </div>
 
-      <hr className="mb-4 border-border-heavy" />
+      <hr className="border-border-heavy" />
 
-      <div className="mx-3">
+      <div className="bg-surface-tertiary-alt px-3 py-4">
         <Instructions />
       </div>
 

--- a/client/src/components/SidePanel/Agents/AgentFooter.tsx
+++ b/client/src/components/SidePanel/Agents/AgentFooter.tsx
@@ -99,7 +99,7 @@ export default function AgentFooter({
    * Make sure to check that the LibreChat implementation hasn't drifted too far functionality-wise!
    */
   return (
-    <div>
+    <div className="bg-surface-tertiary-alt">
       {/* Advanced settings */}
       {showButtons && (
         <div data-testid="advanced-button">
@@ -139,7 +139,7 @@ export default function AgentFooter({
 
       {/* Run agent */}
       {!isEphemeralAgent(agent_id) && (
-        <div className="px-4">
+        <div className="px-4 pb-4">
           <button
             className="btn btn-neutral w-full justify-center"
             onClick={(e) => {

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -486,7 +486,7 @@ export default function AgentPanel() {
     <FormProvider {...methods}>
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="scrollbar-gutter-stable flex flex-1 flex-col pb-3"
+        className="scrollbar-gutter-stable flex flex-1 flex-col"
         aria-label="Agent configuration form"
       >
         <div className="flex-1">

--- a/client/src/components/SidePanel/Agents/Instructions.tsx
+++ b/client/src/components/SidePanel/Agents/Instructions.tsx
@@ -54,7 +54,7 @@ export default function Instructions() {
   };
 
   return (
-    <div className="mb-4">
+    <div>
       <div className="mb-2 flex items-center">
         {/* NJ: Customize how we explain the Instructions feature
         <label

--- a/client/src/nj/components/Agents/AgentBuilderHeader.tsx
+++ b/client/src/nj/components/Agents/AgentBuilderHeader.tsx
@@ -28,9 +28,9 @@ export default function AgentBuilderHeader({
   const showAgentMarketplace = useShowMarketplace();
 
   return (
-    <div className="flex w-full flex-wrap gap-2">
-      <div className="mb-1 mt-4 w-full">
-        <div className="mx-3 flex w-full flex-row items-center justify-between">
+    <div className="flex w-full flex-wrap gap-2 bg-surface-tertiary-alt">
+      <div className="mb-1 w-full">
+        <div className="flex w-full flex-row items-center justify-between bg-surface-primary-alt px-3 pb-4 pt-4">
           <h2 className="py-1 text-xl font-bold">Agent Builder</h2>
 
           {/* "Create new" button, shown only when editing an existing agent */}
@@ -46,7 +46,7 @@ export default function AgentBuilderHeader({
           )}
         </div>
 
-        <hr className="my-4 border-border-medium" />
+        <hr className="mb-4 border-border-medium" />
         <span className="mx-3 text-sm font-semibold">Select an agent to edit</span>
       </div>
 

--- a/client/src/nj/components/Agents/FileContext.tsx
+++ b/client/src/nj/components/Agents/FileContext.tsx
@@ -77,7 +77,7 @@ export default function FileContext({
 
       <hr className="border-border-heavy" />
 
-      <div className="flex flex-col gap-3 bg-presentation px-3 pb-4 pt-4">
+      <div className="flex flex-col gap-3 bg-surface-tertiary-alt px-3 pb-4 pt-4">
         {/* File Search (RAG API) Files */}
         <FileRow
           files={files}

--- a/client/src/nj/components/Agents/FileSearch.tsx
+++ b/client/src/nj/components/Agents/FileSearch.tsx
@@ -83,7 +83,7 @@ export default function FileSearch({
       <hr className="border-border-heavy" />
 
       {fileSearchChecked && (
-        <div className="flex flex-col gap-3 bg-presentation px-3 pb-4 pt-4">
+        <div className="flex flex-col gap-3 bg-surface-tertiary-alt px-3 pb-4 pt-4">
           {/* File Search (RAG API) Files */}
           <FileRow
             files={files}


### PR DESCRIPTION
The headers should be surface-primary-alt whereas the input areas should be surface-tertiary-alt.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1719

Before:

<img width="559" height="1191" alt="Screenshot 2026-05-29 at 10 03 37 AM" src="https://github.com/user-attachments/assets/32a28cb8-7a3c-4454-83eb-c98061027e8d" />

After:

<img width="559" height="1180" alt="Screenshot 2026-05-29 at 10 03 06 AM" src="https://github.com/user-attachments/assets/5326fd93-80ee-4d6e-b73e-6e3bdf0d3739" />
