### PR TITLE
Use consistent builder input styling

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -235,6 +235,9 @@ export default function AgentConfig() {
    *
    * Make sure to check that the LibreChat implementation hasn't drifted too far functionality-wise!
    */
+  const njInputClass =
+    'flex w-full rounded-md border border-[#454540] px-3 py-2 text-sm placeholder:text-text-secondary';
+
   return (
     <div className="h-auto pt-3">
       {/* Identity */}
@@ -262,7 +265,7 @@ export default function AgentConfig() {
                 {...field}
                 value={field.value ?? ''}
                 maxLength={256}
-                className={inputClass}
+                className={njInputClass}
                 id="name"
                 type="text"
                 placeholder="Required: give your agent a name"
@@ -293,7 +296,7 @@ export default function AgentConfig() {
               {...field}
               value={field.value ?? ''}
               maxLength={512}
-              className={inputClass}
+              className={njInputClass}
               id="description"
               type="text"
               placeholder={localize('com_agents_description_placeholder')}
@@ -311,7 +314,7 @@ export default function AgentConfig() {
         <p className="mt-1 text-sm text-text-secondary">
           Define what your agent does, how it behaves, and what it should focus on.
         </p>
-        <p className="mt-1 text-xs text-text-secondary">
+        <p className="mt-1 text-sm text-text-secondary">
           Read example instructions in the{' '}
           <a
             href="https://innovation.nj.gov/skills/ai-how-tos/"

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -43,6 +43,7 @@ import { X } from 'lucide-react';
 import TipComponent from '~/nj/components/TipComponent';
 import FileContext from '~/nj/components/Agents/FileContext';
 import FileSearch from '~/nj/components/Agents/FileSearch';
+import { njInputClass } from '~/nj/components/Agents/agentInputStyle';
 
 const sectionLabelClass = 'text-sm font-semibold';
 const labelClass = 'mb-2 text-token-text-primary block text-sm font-semibold';
@@ -235,9 +236,6 @@ export default function AgentConfig() {
    *
    * Make sure to check that the LibreChat implementation hasn't drifted too far functionality-wise!
    */
-  const njInputClass =
-    'flex w-full rounded-md border border-[#454540] px-3 py-2 text-sm placeholder:text-text-secondary';
-
   return (
     <div className="h-auto pt-3">
       {/* Identity */}

--- a/client/src/components/SidePanel/Agents/AgentFooter.tsx
+++ b/client/src/components/SidePanel/Agents/AgentFooter.tsx
@@ -147,7 +147,7 @@ export default function AgentFooter({
               handleSelectAgent();
             }}
           >
-            Run agent
+            <span className="font-bold underline hover:decoration-2">Run agent</span>
           </button>
         </div>
       )}

--- a/client/src/components/SidePanel/Agents/Instructions.tsx
+++ b/client/src/components/SidePanel/Agents/Instructions.tsx
@@ -99,7 +99,7 @@ export default function Instructions() {
               <Menu.MenuButton
                 id="variables-menu-button"
                 aria-label="Add variable to instructions"
-                className="flex h-7 items-center gap-1 rounded-md border border-border-medium bg-surface-secondary px-2 py-0 text-sm text-text-primary transition-colors duration-200 hover:bg-surface-tertiary"
+                className="flex h-7 items-center gap-1 rounded-md border border-border-medium bg-surface-primary-alt px-2 py-0 text-sm text-text-primary transition-colors duration-200 hover:bg-surface-tertiary"
               >
                 <PlusCircle className="mr-1 h-3 w-3 text-text-secondary" aria-hidden={true} />
                 {localize('com_ui_variables')}

--- a/client/src/components/SidePanel/Agents/Instructions.tsx
+++ b/client/src/components/SidePanel/Agents/Instructions.tsx
@@ -19,6 +19,7 @@ import type { TSpecialVarLabel } from 'librechat-data-provider';
 import type { AgentForm } from '~/common';
 import { cn, defaultTextProps, removeFocusOutlines } from '~/utils';
 import { useLocalize } from '~/hooks';
+import { njInputClass } from '~/nj/components/Agents/agentInputStyle';
 
 const inputClass = cn(
   defaultTextProps,
@@ -122,7 +123,7 @@ export default function Instructions() {
             <textarea
               {...field}
               value={field.value ?? ''}
-              className={cn(inputClass, 'min-h-[100px] resize-y')}
+              className={cn(njInputClass, 'min-h-[100px] resize-y')}
               id="instructions"
               placeholder={localize('com_agents_instructions_placeholder')}
               rows={3}

--- a/client/src/nj/components/Agents/AddFilesButton.tsx
+++ b/client/src/nj/components/Agents/AddFilesButton.tsx
@@ -22,7 +22,7 @@ export default function AddFilesButton({
     <>
       {hasFiles ? (
         <button type="button" className="btn btn-neutral" onClick={onClick}>
-          <div className="flex w-full items-center gap-1 text-sm font-semibold text-jersey-blue">
+          <div className="flex w-full items-center gap-1 text-sm font-semibold text-jersey-blue underline hover:decoration-2">
             <Plus aria-hidden="true" size={18} />
             Add files
           </div>

--- a/client/src/nj/components/Agents/AgentBuilderHeader.tsx
+++ b/client/src/nj/components/Agents/AgentBuilderHeader.tsx
@@ -29,8 +29,8 @@ export default function AgentBuilderHeader({
 
   return (
     <div className="flex w-full flex-wrap gap-2">
-      <div className="mx-3 mb-1 mt-4 w-full">
-        <div className="flex w-full flex-row items-center justify-between">
+      <div className="mb-1 mt-4 w-full">
+        <div className="mx-3 flex w-full flex-row items-center justify-between">
           <h2 className="py-1 text-xl font-bold">Agent Builder</h2>
 
           {/* "Create new" button, shown only when editing an existing agent */}
@@ -47,7 +47,7 @@ export default function AgentBuilderHeader({
         </div>
 
         <hr className="my-4 border-border-medium" />
-        <span className="text-sm font-semibold">Select an agent to edit</span>
+        <span className="mx-3 text-sm font-semibold">Select an agent to edit</span>
       </div>
 
       {/* Select agent to edit */}

--- a/client/src/nj/components/Agents/FileContext.tsx
+++ b/client/src/nj/components/Agents/FileContext.tsx
@@ -110,7 +110,7 @@ export default function FileContext({
         {/* Disabled Message */}
         {!agent_id && (
           <div className="text-center text-sm text-text-secondary">
-            {localize('com_agents_file_search_disabled')}
+            {localize('com_agents_file_context_disabled')}
           </div>
         )}
       </div>

--- a/client/src/nj/components/Agents/agentInputStyle.ts
+++ b/client/src/nj/components/Agents/agentInputStyle.ts
@@ -1,0 +1,2 @@
+export const njInputClass =
+  'flex w-full rounded-md border border-[#454540] px-3 py-2 text-sm placeholder:text-text-secondary';

--- a/client/src/nj/components/NewJerseyPanelButton.tsx
+++ b/client/src/nj/components/NewJerseyPanelButton.tsx
@@ -13,7 +13,7 @@ export default function NewJerseyPanelButton({
     <button
       type="button"
       onClick={() => setActivePanel(Panel.advanced)}
-      className="flex w-full items-center justify-between bg-surface-tertiary px-3 py-4 text-left"
+      className="flex w-full items-center justify-between bg-surface-tertiary px-3 py-4 text-left hover:bg-[#E6E6E2]"
     >
       <span className="text-token-text-primary text-sm font-semibold">{label}</span>
       <ChevronRight className="text-token-text-primary h-4 w-4" aria-hidden />


### PR DESCRIPTION
The same styles were being used for agent name/description, but not for the instructions field. Now it's all using the same thing!

Part of https://github.com/newjersey/innovation-platform-pm/issues/1719

Before:

<img width="518" height="180" alt="Screenshot 2026-05-29 at 10 06 05 AM" src="https://github.com/user-attachments/assets/26af9fc9-da22-433c-9864-f4cf0b42529d" />

After:


<img width="517" height="181" alt="Screenshot 2026-05-29 at 10 05 55 AM" src="https://github.com/user-attachments/assets/78629082-7234-4db4-aee7-5656f66e96af" />
