### PR TITLE
Fix kitchensink deployment failure

### DIFF
--- a/.github/workflows/nj-kitchensink-build.yml
+++ b/.github/workflows/nj-kitchensink-build.yml
@@ -49,9 +49,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Redeploy kitchensink from latest
-        # uses: apideck-libraries/ecs-restart-service@v1
-        run: |
-          aws ecs update-service \
-            --cluster "${{ secrets.KITCHENSINK_CLUSTER_NAME }}" \
-            --service "${{ secrets.KITCHENSINK_SERVICE_NAME }}" \
-            --force-new-deployment
+        uses: apideck-libraries/ecs-restart-service@v1
+        with:
+          service: ${{ secrets.KITCHENSINK_SERVICE_NAME }}
+          cluster: ${{ secrets.KITCHENSINK_CLUSTER_NAME }}


### PR DESCRIPTION
## Description
This PR reverts the `Redeploy kitchensink from latest` step from running `aws ecs update-service` (used to debug error) to using `apideck-libraries`.  

Using `aws ecs update-service` revealed a `ServiceNotFoundException` error. I updated the relevant GitHub secret and the step completed successfully. The step should also now pass with the `apideck library` reinstated. 🤞🏾

## Ticket 
Refers to [Fix: Kitchen Sink Auto-Deployment Issue](https://github.com/newjersey/innovation-platform-pm/issues/1749)


