### PR TITLE
feat: add `convo.pinned`

### DIFF
--- a/api/nj/routes/convos/convos.js
+++ b/api/nj/routes/convos/convos.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const { logger } = require('@librechat/data-schemas');
+const { validateConvoAccess } = require('~/server/middleware');
+const requireJwtAuth = require('~/server/middleware/requireJwtAuth');
+const db = require('~/models');
+
+const router = express.Router();
+router.use(requireJwtAuth);
+
+router.post('/pin', validateConvoAccess, async (req, res) => {
+  const { conversationId, pinned } = req.body?.arg ?? {};
+
+  if (!conversationId) {
+    return res.status(400).json({ error: 'conversationId is required' });
+  }
+
+  if (pinned === undefined) {
+    return res.status(400).json({ error: 'pinned is required' });
+  }
+
+  if (typeof pinned !== 'boolean') {
+    return res.status(400).json({ error: 'pinned must be a boolean' });
+  }
+
+  try {
+    const dbResponse = await db.saveConvo(
+      { userId: req.user.id },
+      { conversationId, pinned },
+      { context: `POST /api/convos/pin ${conversationId}` },
+    );
+    res.status(200).json(dbResponse);
+  } catch (error) {
+    logger.error('Error pinning conversation', error);
+    res.status(500).send('Error pinning conversation');
+  }
+});
+
+module.exports = router;

--- a/api/nj/routes/convos/convos.spec.js
+++ b/api/nj/routes/convos/convos.spec.js
@@ -1,0 +1,118 @@
+const express = require('express');
+const request = require('supertest');
+
+const MOCKS = '../../../server/routes/__test-utils__/convos-route-mocks';
+
+jest.mock('@librechat/agents', () => require(MOCKS).agents());
+jest.mock('@librechat/api', () => require(MOCKS).api());
+jest.mock('@librechat/data-schemas', () => require(MOCKS).dataSchemas());
+jest.mock('librechat-data-provider', () => require(MOCKS).dataProvider());
+jest.mock('~/models', () => require(MOCKS).sharedModels());
+jest.mock('~/server/middleware/requireJwtAuth', () => require(MOCKS).requireJwtAuth());
+jest.mock('~/server/middleware', () => require(MOCKS).middlewarePassthrough());
+jest.mock('~/server/utils/import/fork', () => require(MOCKS).forkUtils());
+jest.mock('~/server/utils/import', () => require(MOCKS).importUtils());
+jest.mock('~/cache/getLogStores', () => require(MOCKS).logStores());
+jest.mock('~/server/routes/files/multer', () => require(MOCKS).multerSetup());
+jest.mock('multer', () => require(MOCKS).multerLib());
+jest.mock('~/server/services/Endpoints/azureAssistants', () => require(MOCKS).assistantEndpoint());
+jest.mock('~/server/services/Endpoints/assistants', () => require(MOCKS).assistantEndpoint());
+
+describe('Convos Routes', () => {
+  let app;
+  let convosRouter;
+  const { saveConvo } = require('~/models');
+
+  beforeAll(() => {
+    convosRouter = require('../../../server/routes/convos');
+
+    app = express();
+    app.use(express.json());
+
+    /** Mock authenticated user */
+    app.use((req, res, next) => {
+      req.user = { id: 'test-user-123' };
+      next();
+    });
+
+    app.use('/api/convos', convosRouter);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /convos/pin', () => {
+    const mockConversationId = 'conv-123';
+
+    it('should pin a conversation', async () => {
+      const mockPinnedConvo = { conversationId: mockConversationId, pinned: true };
+      saveConvo.mockResolvedValue(mockPinnedConvo);
+
+      const response = await request(app).post('/api/convos/pin').send({ arg: mockPinnedConvo });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(mockPinnedConvo);
+      expect(saveConvo).toHaveBeenCalledWith(
+        { userId: 'test-user-123' },
+        { conversationId: mockConversationId, pinned: true },
+        { context: `POST /api/convos/pin ${mockConversationId}` },
+      );
+    });
+
+    it('should unpin a conversation', async () => {
+      const mockUnpinnedConvo = { conversationId: mockConversationId, pinned: false };
+      saveConvo.mockResolvedValue(mockUnpinnedConvo);
+
+      const response = await request(app).post('/api/convos/pin').send({ arg: mockUnpinnedConvo });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(mockUnpinnedConvo);
+      expect(saveConvo).toHaveBeenCalledWith(
+        { userId: 'test-user-123' },
+        { conversationId: mockConversationId, pinned: false },
+        { context: `POST /api/convos/pin ${mockConversationId}` },
+      );
+    });
+
+    it('should return 400 when conversationId is missing', async () => {
+      const response = await request(app)
+        .post('/api/convos/pin')
+        .send({ arg: { pinned: true } });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ error: 'conversationId is required' });
+      expect(saveConvo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when pinned is not a boolean', async () => {
+      const response = await request(app)
+        .post('/api/convos/pin')
+        .send({ arg: { conversationId: mockConversationId, pinned: 'yes' } });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ error: 'pinned must be a boolean' });
+      expect(saveConvo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when pinned is missing', async () => {
+      const response = await request(app)
+        .post('/api/convos/pin')
+        .send({ arg: { conversationId: mockConversationId } });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ error: 'pinned is required' });
+      expect(saveConvo).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 when saveConvo fails', async () => {
+      saveConvo.mockRejectedValue(new Error('Database error'));
+
+      const response = await request(app)
+        .post('/api/convos/pin')
+        .send({ arg: { conversationId: mockConversationId, pinned: true } });
+
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -202,6 +202,8 @@ router.post('/archive', validateConvoAccess, async (req, res) => {
   }
 });
 
+router.use('/', require('../../nj/routes/convos/convos'));
+
 /** Maximum allowed length for conversation titles */
 const MAX_CONVO_TITLE_LENGTH = 1024;
 

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -860,6 +860,7 @@ export const tConversationSchema = z.object({
   endpoint: eModelEndpointSchema.nullable(),
   endpointType: eModelEndpointSchema.nullable().optional(),
   isArchived: z.boolean().optional(),
+  pinned: z.boolean().optional(),
   title: z.string().nullable().or(z.literal('New Chat')).default('New Chat'),
   user: z.string().optional(),
   messages: z.array(z.string()).optional(),

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -1,17 +1,16 @@
-import type { FilterQuery, Model, SortOrder } from 'mongoose';
 import { RetentionMode } from 'librechat-data-provider';
-import { isValidObjectIdString } from '~/utils/objectId';
-import { createTempChatExpirationDate } from '~/utils/tempChatRetention';
-import { buildRetentionVisibilityFilter, createFallbackRetentionDate } from '~/utils/retention';
-import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
-import logger from '~/config/winston';
+import type { DeleteResult, FilterQuery, Model, SortOrder } from 'mongoose';
 import type { AppConfig, IChatProjectDocument, IConversation } from '~/types';
+import type { MessageMethods } from './message';
 import {
   refreshChatProjectStatsForUser,
   updateChatProjectLastConversationForUser,
 } from './chatProject';
-import type { MessageMethods } from './message';
-import type { DeleteResult } from 'mongoose';
+import { buildRetentionVisibilityFilter, createFallbackRetentionDate } from '~/utils/retention';
+import { createTempChatExpirationDate } from '~/utils/tempChatRetention';
+import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
+import { isValidObjectIdString } from '~/utils/objectId';
+import logger from '~/config/winston';
 
 export interface ConversationMethods {
   getConvoFiles(conversationId: string): Promise<string[]>;
@@ -640,7 +639,7 @@ export function createConversationMethods(
 
       const convos = await Conversation.find(query)
         .select(
-          'conversationId endpoint title createdAt updatedAt user model agent_id assistant_id spec iconURL chatProjectId',
+          'conversationId endpoint title createdAt updatedAt user model agent_id assistant_id spec iconURL chatProjectId pinned',
         )
         .sort(sortObj)
         .limit(limit + 1)

--- a/packages/data-schemas/src/schema/convo.ts
+++ b/packages/data-schemas/src/schema/convo.ts
@@ -49,6 +49,9 @@ const convoSchema: Schema<IConversation> = new Schema(
       type: String,
       index: true,
     },
+    pinned: {
+      type: Boolean,
+    },
   },
   { timestamps: true },
 );

--- a/packages/data-schemas/src/types/convo.ts
+++ b/packages/data-schemas/src/types/convo.ts
@@ -38,6 +38,7 @@ export interface IConversation extends Document {
   instructions?: string;
   stop?: string[];
   isArchived?: boolean;
+  pinned?: boolean;
   iconURL?: string;
   greeting?: string;
   spec?: string;


### PR DESCRIPTION
We want to be able to pin convos (so users can easily find them), thus we added a new field to the DB schema: `pinned`.

We also had to add an API method for pinning a convo. It's got thorough tests. It's structured just like how /api/convos/archive works, only for pinning.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1728