### PR TITLE
feat: add 'pinned' section to conversation list

### DIFF
--- a/client/src/components/Conversations/Conversations.tsx
+++ b/client/src/components/Conversations/Conversations.tsx
@@ -137,6 +137,17 @@ const ChatsHeader: FC<ChatsHeaderProps> = memo(({ isExpanded, onToggle }) => {
 
 ChatsHeader.displayName = 'ChatsHeader';
 
+const PinnedHeader: FC = memo(() => {
+  const localize = useLocalize();
+  return (
+    <h2 className="pl-1 pt-1 text-text-secondary" style={{ fontSize: '0.7rem' }}>
+      {localize('com_ui_pinned')}
+    </h2>
+  );
+});
+
+PinnedHeader.displayName = 'PinnedHeader';
+
 const DateLabel: FC<{ groupName: string; isFirst?: boolean }> = memo(({ groupName, isFirst }) => {
   const localize = useLocalize();
   return (
@@ -158,6 +169,8 @@ DateLabel.displayName = 'DateLabel';
 
 type FlattenedItem =
   | { type: 'favorites' }
+  | { type: 'pinned-header' }
+  | { type: 'pinned-convo'; convo: TConversation }
   | { type: 'header'; groupName: string }
   | { type: 'convo'; convo: TConversation }
   | { type: 'loading' };
@@ -203,6 +216,11 @@ const Conversations: FC<ConversationsProps> = ({
     [rawConversations],
   );
 
+  const pinnedConversations = useMemo(
+    () => filteredConversations.filter((c) => c.pinned),
+    [filteredConversations],
+  );
+
   const groupedConversations = useMemo(
     () => groupConversationsByDate(filteredConversations),
     [filteredConversations],
@@ -216,6 +234,13 @@ const Conversations: FC<ConversationsProps> = ({
     }
 
     if (isChatsExpanded) {
+      if (!search.query && pinnedConversations.length > 0) {
+        items.push({ type: 'pinned-header' });
+        items.push(
+          ...pinnedConversations.map((convo) => ({ type: 'pinned-convo' as const, convo })),
+        );
+      }
+
       groupedConversations.forEach(([groupName, convos]) => {
         items.push({ type: 'header', groupName });
         items.push(...convos.map((convo) => ({ type: 'convo' as const, convo })));
@@ -226,7 +251,14 @@ const Conversations: FC<ConversationsProps> = ({
       }
     }
     return items;
-  }, [groupedConversations, isLoading, isChatsExpanded, shouldShowFavorites]);
+  }, [
+    groupedConversations,
+    pinnedConversations,
+    isLoading,
+    isChatsExpanded,
+    shouldShowFavorites,
+    search.query,
+  ]);
 
   // Store flattenedItems in a ref for keyMapper to access without recreating cache
   const flattenedItemsRef = useRef(flattenedItems);
@@ -245,6 +277,12 @@ const Conversations: FC<ConversationsProps> = ({
           }
           if (item.type === 'favorites') {
             return `favorites-${favoritesContentKeyRef.current}`;
+          }
+          if (item.type === 'pinned-header') {
+            return 'pinned-header';
+          }
+          if (item.type === 'pinned-convo') {
+            return `pinned-${item.convo.conversationId}`;
           }
           if (item.type === 'header') {
             return `header-${item.groupName}`;
@@ -308,9 +346,33 @@ const Conversations: FC<ConversationsProps> = ({
         );
       }
 
+      if (item.type === 'pinned-header') {
+        return (
+          <MeasuredRow key={key} {...rowProps}>
+            <PinnedHeader />
+          </MeasuredRow>
+        );
+      }
+
+      if (item.type === 'pinned-convo') {
+        const isGenerating = activeJobIds.has(item.convo.conversationId ?? '');
+        return (
+          <MeasuredRow key={key} {...rowProps}>
+            <Convo
+              conversation={item.convo}
+              retainView={moveToTop}
+              toggleNav={toggleNav}
+              isGenerating={isGenerating}
+            />
+          </MeasuredRow>
+        );
+      }
+
       if (item.type === 'header') {
-        // First date header index depends on whether the favorites row is included
-        const firstHeaderIndex = shouldShowFavorites ? 1 : 0;
+        // First date header index depends on favorites row, pinned header, and pinned convos
+        // At most: [favorites, pinned-header, # pinned-convos] → first-header
+        const pinnedOffset = pinnedConversations.length > 0 ? pinnedConversations.length + 1 : 0;
+        const firstHeaderIndex = (flattenedItems[0]?.type === 'favorites' ? 1 : 0) + pinnedOffset;
         return (
           <MeasuredRow key={key} {...rowProps}>
             <DateLabel groupName={item.groupName} isFirst={index === firstHeaderIndex} />
@@ -334,7 +396,7 @@ const Conversations: FC<ConversationsProps> = ({
 
       return null;
     },
-    [cache, flattenedItems, moveToTop, toggleNav, isSmallScreen, shouldShowFavorites, activeJobIds],
+    [cache, flattenedItems, moveToTop, toggleNav, isSmallScreen, pinnedConversations, activeJobIds],
   );
 
   const getRowHeight = useCallback(

--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { Pin } from 'lucide-react';
 import { useRecoilValue } from 'recoil';
 import { useParams } from 'react-router-dom';
 import { Constants } from 'librechat-data-provider';
@@ -275,6 +276,9 @@ function Conversation({
           <ConversationEndpointIcon conversation={conversation} size={20} context="menu-item" />
           */}
         </ConvoLink>
+      )}
+      {conversation.pinned === true && (
+        <Pin className="icon-sm mr-1 shrink-0 text-text-primary" aria-hidden="true" />
       )}
       <div
         className={cn(

--- a/client/src/components/Conversations/__tests__/Conversations.test.tsx
+++ b/client/src/components/Conversations/__tests__/Conversations.test.tsx
@@ -3,6 +3,9 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { RecoilRoot } from 'recoil';
 import type { CellMeasurerCache, List } from 'react-virtualized';
+import type { TConversation } from 'librechat-data-provider';
+import Conversations from '../Conversations';
+import store from '~/store';
 
 let mockCapturedCache: CellMeasurerCache | null = null;
 
@@ -109,8 +112,6 @@ jest.mock('../Convo', () => ({
   default: () => <div data-testid="convo" />,
 }));
 
-import Conversations from '../Conversations';
-
 describe('Conversations – favorites CellMeasurerCache key invalidation', () => {
   const containerRef = createRef<List>();
 
@@ -193,5 +194,67 @@ describe('Conversations – favorites CellMeasurerCache key invalidation', () =>
 
     expect(cache.has(0, 0)).toBe(true);
     expect(cache.getHeight(0, 0)).toBe(88);
+  });
+});
+
+const pinnedConvo = {
+  conversationId: 'pinned-1',
+  title: 'Pinned Chat',
+  pinned: true,
+  endpoint: 'openAI',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+} as TConversation;
+
+describe('Conversations – pinned header', () => {
+  const containerRef = createRef<List>();
+
+  beforeEach(() => {
+    mockCapturedCache = null;
+    mockFavoritesState.favorites = [];
+    mockFavoritesState.isLoading = false;
+    mockShowMarketplace = false;
+  });
+
+  const renderConversations = (conversations: TConversation[], searchQuery = '') =>
+    render(
+      <RecoilRoot
+        initializeState={({ set }) => {
+          set(store.search, {
+            query: searchQuery,
+            enabled: true,
+            debouncedQuery: searchQuery,
+            isSearching: true,
+            isTyping: false,
+          });
+        }}
+      >
+        <Conversations
+          conversations={conversations}
+          moveToTop={jest.fn()}
+          toggleNav={jest.fn()}
+          containerRef={containerRef}
+          loadMoreConversations={jest.fn()}
+          isLoading={false}
+          isSearchLoading={false}
+          isChatsExpanded={true}
+          setIsChatsExpanded={jest.fn()}
+        />
+      </RecoilRoot>,
+    );
+
+  it('shows the pinned header when there are pinned conversations', () => {
+    const { getByText } = renderConversations([pinnedConvo]);
+    expect(getByText('com_ui_pinned')).toBeInTheDocument();
+  });
+
+  it('does not show the pinned header when there are no pinned conversations', () => {
+    const { queryByText } = renderConversations([]);
+    expect(queryByText('com_ui_pinned')).not.toBeInTheDocument();
+  });
+
+  it('does not show the pinned header during search', () => {
+    const { queryByText } = renderConversations([pinnedConvo], 'some query');
+    expect(queryByText('com_ui_pinned')).not.toBeInTheDocument();
   });
 });

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1345,6 +1345,7 @@
   "com_ui_permissions_failed_update": "Failed to update permissions. Please try again.",
   "com_ui_permissions_updated_success": "Permissions updated successfully",
   "com_ui_pin": "Pin",
+  "com_ui_pinned": "Pinned",
   "com_ui_plus_n_more": "+{{0}} more",
   "com_ui_preferences_updated": "Preferences updated successfully",
   "com_ui_prev": "Prev",

--- a/client/src/utils/convos.spec.ts
+++ b/client/src/utils/convos.spec.ts
@@ -145,6 +145,23 @@ describe('Conversation Utilities', () => {
       expect(grouped[1][1].length).toBe(1);
     });
 
+    it('excludes pinned conversations from date groups', () => {
+      const conversations = [
+        { conversationId: '1', updatedAt: new Date().toISOString(), pinned: true },
+        { conversationId: '2', updatedAt: new Date().toISOString() },
+        { conversationId: '3', updatedAt: '2023-06-01T12:00:00Z', pinned: true },
+        { conversationId: '4', updatedAt: '2023-06-01T12:00:00Z' },
+      ];
+
+      const grouped = groupConversationsByDate(conversations as TConversation[]);
+
+      const allGroupedIds = grouped.flatMap(([, convs]) => convs.map((c) => c.conversationId));
+      expect(allGroupedIds).not.toContain('1');
+      expect(allGroupedIds).not.toContain('3');
+      expect(allGroupedIds).toContain('2');
+      expect(allGroupedIds).toContain('4');
+    });
+
     it('correctly groups and sorts conversations for every month of the year', () => {
       const months = [
         'january',

--- a/client/src/utils/convos.ts
+++ b/client/src/utils/convos.ts
@@ -88,7 +88,11 @@ export const groupConversationsByDate = (
   const now = new Date(Date.now());
 
   conversations.forEach((conversation) => {
-    if (!conversation || seenConversationIds.has(conversation.conversationId)) {
+    if (
+      !conversation ||
+      seenConversationIds.has(conversation.conversationId) ||
+      conversation.pinned
+    ) {
       return;
     }
     seenConversationIds.add(conversation.conversationId);


### PR DESCRIPTION
If there are any pinned conversations, they will appear above the normal "chats" list, with a pinned icon next to them.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1728

Here's how it looks:

<img width="367" height="282" alt="Screenshot 2026-06-02 at 2 40 19 PM" src="https://github.com/user-attachments/assets/c2657039-27c1-412d-bbff-fa4ee71d2d8d" />
