### PR TITLE
fix: adjust ellipsizing gradient on ConvoLink

### DIFF
--- a/client/src/components/Conversations/ConvoLink.tsx
+++ b/client/src/components/Conversations/ConvoLink.tsx
@@ -45,16 +45,16 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
         aria-label={title || localize('com_ui_untitled')}
       >
         {title || localize('com_ui_untitled')}
+        <div
+          className={cn(
+            'pointer-events-none absolute bottom-0 right-0 top-0 w-20 bg-gradient-to-l',
+            isActiveConvo || isPopoverActive
+              ? 'from-surface-active-alt'
+              : 'from-surface-primary-alt from-0% to-transparent group-hover:from-surface-active-alt group-hover:from-0%',
+          )}
+          aria-hidden="true"
+        />
       </div>
-      <div
-        className={cn(
-          'pointer-events-none absolute bottom-0.5 right-0.5 top-0.5 w-20 rounded-r-md bg-gradient-to-l',
-          isActiveConvo || isPopoverActive
-            ? 'from-surface-active-alt'
-            : 'from-surface-primary-alt from-0% to-transparent group-hover:from-surface-active-alt group-hover:from-40%',
-        )}
-        aria-hidden="true"
-      />
     </div>
   );
 };


### PR DESCRIPTION
Because it went across the whole ConvoLink, it would cover up any children (i.e. icons) that appear after the title. However, the point of the gradient is just to gradually make the title disappear, not the icons.

This change places the gradient on the title only, so it achieves the same ellipsizing effect without interfering with the display of the child icons.

Part of Part of https://github.com/newjersey/innovation-platform-pm/issues/1728

-----

Before:

<img width="300" height="121" alt="Screenshot 2026-06-02 at 2 41 24 PM" src="https://github.com/user-attachments/assets/9d2207ac-0eb5-4b4e-b9a2-da1650a05224" />

After:

<img width="307" height="121" alt="Screenshot 2026-06-02 at 2 41 09 PM" src="https://github.com/user-attachments/assets/f1143b6a-25b0-474e-a6f8-ff09302c5212" />
