### PR TITLE
Hide message nav until accessible

### DIFF
--- a/client/src/components/Chat/Messages/MessagesView.tsx
+++ b/client/src/components/Chat/Messages/MessagesView.tsx
@@ -94,7 +94,9 @@ function MessagesViewContent({
             <ScrollToBottom ref={scrollToBottomRef} scrollHandler={handleSmoothToRef} />
           </CSSTransition>
 
+          {/* NJ: We're hiding this until it's made more accessible
           <MessageNav scrollableRef={scrollableRef} />
+          */}
         </div>
       </div>
     </>


### PR DESCRIPTION
It works pretty well for sighted users, but it doesn't move focus, which means that using it is really hard for a keyboard user.