### PR TITLE
Rework the noisiest alarms

### DIFF
--- a/nj/infra/lib/monitoring-stack.ts
+++ b/nj/infra/lib/monitoring-stack.ts
@@ -2,6 +2,8 @@ import * as cdk from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as cwActions from 'aws-cdk-lib/aws-cloudwatch-actions';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as eventTargets from 'aws-cdk-lib/aws-events-targets';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
@@ -29,6 +31,18 @@ export class MonitoringStack extends cdk.Stack {
 
     const topic = this.createSNSTopic();
     this.createAlarms(topic, loadBalancer, targetGroup, props);
+    this.createBedrockHealthEventRule(topic);
+  }
+
+  private createBedrockHealthEventRule(topic: sns.Topic) {
+    new events.Rule(this, 'BedrockHealthEvents', {
+      eventPattern: {
+        source: ['aws.health'],
+        detailType: ['AWS Health Event'],
+        detail: { service: ['BEDROCK'] },
+      },
+      targets: [new eventTargets.SnsTopic(topic)],
+    });
   }
 
   private createSNSTopic() {
@@ -193,42 +207,47 @@ export class MonitoringStack extends cdk.Stack {
       }),
       threshold: 1,
       evaluationPeriods: 5,
-      datapointsToAlarm: 3,
+      datapointsToAlarm: 5,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
     });
     bedrockServerErrorsAlarm.addAlarmAction(new cwActions.SnsAction(topic));
 
-    for (const [id, metricName, stat, alarmName] of [
-      [
-        'BedrockInvocationLatency',
-        'InvocationLatency',
-        'p50',
-        'ai-assistant-bedrock-invocation-latency-p50',
-      ],
-      [
-        'BedrockModelInvocations',
-        'ModelInvocations',
-        'Sum',
-        'ai-assistant-bedrock-model-invocations',
-      ],
-    ] as const) {
-      const alarm = new cloudwatch.AnomalyDetectionAlarm(this, id, {
-        alarmName: this.makeAlarmName(alarmName),
+    const modelInvocationsAlarm = new cloudwatch.AnomalyDetectionAlarm(
+      this,
+      'BedrockModelInvocations',
+      {
+        alarmName: this.makeAlarmName('ai-assistant-bedrock-model-invocations'),
         metric: new cloudwatch.Metric({
           namespace: 'AWS/Bedrock',
-          metricName,
+          metricName: 'ModelInvocations',
           period: Duration.minutes(1),
-          statistic: stat,
+          statistic: 'Sum',
         }),
         stdDevs: 2,
         comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_UPPER_THRESHOLD,
         evaluationPeriods: 5,
         datapointsToAlarm: 3,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      });
-      alarm.addAlarmAction(new cwActions.SnsAction(topic));
-    }
+      },
+    );
+    modelInvocationsAlarm.addAlarmAction(new cwActions.SnsAction(topic));
+
+    const ttftAlarm = new cloudwatch.Alarm(this, 'BedrockTimeToFirstToken', {
+      alarmName: this.makeAlarmName('ai-assistant-bedrock-time-to-first-token'),
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/Bedrock',
+        metricName: 'TimeToFirstToken',
+        period: Duration.minutes(3),
+        statistic: 'Average',
+      }),
+      threshold: 15_000,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+      treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+    });
+    ttftAlarm.addAlarmAction(new cwActions.SnsAction(topic));
   }
 
   private createAlbLatencyAlarms(topic: sns.Topic, loadBalancer: elbv2.IApplicationLoadBalancer) {


### PR DESCRIPTION
Ticket https://github.com/newjersey/innovation-platform-pm/issues/1707

This PR replaces the InvocationLatency alarm with an alarm built around Time to First Token (TTFT), it also bumps up the threshold for Server Errors, and adds an event listener for Bedrock Health information from AWS.

I decided to go with a rolling 3-minute average for TTFT, and if the average is ever above 15 seconds, the alarm will trigger. There is a caveat that since our volumes can be pretty low, I chose to IGNORE minutes with zero data rather than treat them as implicitly healthy, but this means an issue occurring late Friday evening may lead the alarm to stay in the triggered state until Monday. IMO the tradeoff is worth it.

I bumped up the threshold for Server Errors, right now it seems to trigger too often from seemingly normal transient issues. Increasing the threshold should allow us to more easily see when the system seems degraded.

As well, I decided to both keep the old Server Errors alarm and also add a subscription for AWS Bedrock Health Events. Here, I think our local alarm will allow us to know if we have local account issues and/or transient issues which AWS doesn't feel rises to the level of AWS reports (or not yet). I think it is nice to know about customer pain without waiting for the customer to report it, even if there is nothing actionable we can do about it. And the Health Events will tell us when there is an outage large enough for AWS to acknowledge it.