### PR TITLE
Remove "files" modal access

### DIFF
--- a/client/src/components/Chat/Input/Files/Table/Columns.tsx
+++ b/client/src/components/Chat/Input/Files/Table/Columns.tsx
@@ -32,7 +32,6 @@ export const columns: ColumnDef<TFile>[] = [
     size: 40,
     header: ({ table }) => {
       const localize = useLocalize();
-      return <></>; // NJ: We don't allow file deletion, and thus selecting files means nothing
       return (
         <TooltipAnchor
           description={localize('com_ui_select_all')}
@@ -54,7 +53,6 @@ export const columns: ColumnDef<TFile>[] = [
     },
     cell: ({ row }) => {
       const localize = useLocalize();
-      return <></>; // NJ: We don't allow file deletion, and thus selecting files means nothing
       return (
         <Checkbox
           checked={row.getIsSelected()}

--- a/client/src/components/Chat/Input/Files/Table/DataTable.tsx
+++ b/client/src/components/Chat/Input/Files/Table/DataTable.tsx
@@ -94,7 +94,6 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
   return (
     <div className="flex h-full flex-col gap-4">
       <div className="flex flex-wrap items-center gap-2 py-2 sm:gap-4 sm:py-4">
-        {/* NJ: Disallow file deletion
         <Button
           variant="outline"
           onClick={() => {
@@ -115,7 +114,6 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
           )}
           {!isSmallScreen && <span className="ml-2">{localize('com_ui_delete')}</span>}
         </Button>
-        */}
         <FilterInput
           inputId="files-filter"
           label={localize('com_files_filter')}

--- a/client/src/components/Nav/AccountSettings.tsx
+++ b/client/src/components/Nav/AccountSettings.tsx
@@ -5,11 +5,10 @@ import { LinkIcon, GearIcon, DropdownMenuSeparator, Avatar } from '@librechat/cl
 import { MyFilesModal } from '~/components/Chat/Input/Files/MyFilesModal';
 import { useGetStartupConfig, useGetUserBalance } from '~/data-provider';
 import { useAuthContext } from '~/hooks/AuthContext';
-import { useHasAccess, useLocalize } from '~/hooks';
+import { useLocalize } from '~/hooks';
 import Settings from './Settings';
 import { NewJerseySelectItems } from '~/nj/components/NewJerseySelectItems';
 import icons from '@uswds/uswds/img/sprite.svg';
-import { Permissions, PermissionTypes } from 'librechat-data-provider';
 
 function AccountSettings({ collapsed = false }: { collapsed?: boolean }) {
   const localize = useLocalize();
@@ -21,10 +20,6 @@ function AccountSettings({ collapsed = false }: { collapsed?: boolean }) {
   const [showSettings, setShowSettings] = useState(false);
   const [showFiles, setShowFiles] = useState(false);
   const accountSettingsButtonRef = useRef<HTMLButtonElement>(null);
-  const hasAccessToFileSearch = useHasAccess({
-    permissionType: PermissionTypes.FILE_SEARCH,
-    permission: Permissions.USE,
-  });
 
   return (
     <Menu.MenuProvider>
@@ -76,15 +71,10 @@ function AccountSettings({ collapsed = false }: { collapsed?: boolean }) {
             <DropdownMenuSeparator />
           </>
         )}
-        */}
-        {/* NJ (Temp feature flag): Conditionally show file attachment until RAG fully enabled */}
-        {hasAccessToFileSearch && (
-          <Menu.MenuItem onClick={() => setShowFiles(true)} className="select-item text-sm">
-            <FileText className="icon-md" aria-hidden="true" />
-            {localize('com_nav_my_files')}
-          </Menu.MenuItem>
-        )}
-        {/*
+        <Menu.MenuItem onClick={() => setShowFiles(true)} className="select-item text-sm">
+          <FileText className="icon-md" aria-hidden="true" />
+          {localize('com_nav_my_files')}
+        </Menu.MenuItem>
         {startupConfig?.helpAndFaqURL !== '/' && (
           <Menu.MenuItem
             onClick={() => window.open(startupConfig?.helpAndFaqURL, '_blank')}


### PR DESCRIPTION
We decided that the side panel was all the files access people need; the modal didn't really serve a purpose (esp. since we don't let people delete files).

Part of https://github.com/newjersey/innovation-platform-pm/issues/1788