### PR TITLE
Use icons instead of file extensions for FileIcon

### DIFF
--- a/client/src/nj/components/SidePanel/Files/FileIcon.tsx
+++ b/client/src/nj/components/SidePanel/Files/FileIcon.tsx
@@ -1,69 +1,27 @@
 import type { TFile } from 'librechat-data-provider';
-import mime from 'mime';
-import { cn } from '~/utils';
+import { FileImage, FileText, type LucideIcon } from 'lucide-react';
 
-const EXTENSION_SPECIAL_CASES: Record<string, string> = {
-  'text/css': 'css',
-  'text/javascript': 'js',
-  'text/x-c': 'c',
-  'text/x-c++': 'cpp',
-  'text/x-csharp': 'cs',
-  'text/x-go': 'go',
-  'text/x-java': 'java',
-  'text/x-kotlin': 'kt',
-  'text/x-lua': 'lua',
-  'text/markdown': 'md',
-  'text/x-perl': 'pl',
-  'text/x-python': 'py',
-  'text/x-r': 'r',
-  'text/x-ruby': 'rb',
-  'text/x-rust': 'rs',
-  'text/x-scala': 'scala',
-  'text/x-swift': 'swift',
-  'text/x-typescript': 'ts',
+// Which icon to render for each mimetype's type (aka <type>/<subtype>)
+// If it's undefined, we'll just render no icon at all
+const TYPE_TO_ICON: Record<string, LucideIcon> = {
+  application: FileText,
+  text: FileText,
+  image: FileImage,
 };
-
-function getExtension(mimetype: string): string {
-  // Special cases not covered by automatic finder (or not covered well)
-  if (mimetype in EXTENSION_SPECIAL_CASES) {
-    return EXTENSION_SPECIAL_CASES[mimetype];
-  }
-
-  // @ts-ignore - LibreChat is using the wrong TS specs w/ their version of mime
-  return mime.getExtension(mimetype) ?? 'file';
-}
-
-const TYPE_TO_CLASS: Record<string, string> = {
-  application: 'file-icon-application',
-  audio: 'file-icon-audio',
-  image: 'file-icon-image',
-  text: 'file-icon-text',
-  video: 'file-icon-video',
-};
-
-function getClassName(mimetype: string): string {
-  const type = mimetype.split('/')[0];
-  return TYPE_TO_CLASS[type] ?? 'file-icon-default';
-}
 
 /**
  * Displays an icon stylized for each file type.
  */
 export default function FileIcon({ file }: { file: TFile }) {
-  const extension = getExtension(file.type);
-  const className = getClassName(file.type);
-  const textSizeClass = extension.length < 4 ? 'text-sm' : 'text-xs';
+  const type = file.type.split('/')[0];
+  const Icon = TYPE_TO_ICON[type];
 
   return (
     <div
-      className={cn(
-        'text-md flex h-10 w-10 flex-shrink-0 items-center justify-center rounded',
-        className,
-        textSizeClass,
-      )}
+      className="text-md file-icon flex h-10 w-10 flex-shrink-0 items-center justify-center rounded"
       aria-hidden="true"
     >
-      {extension.toLocaleUpperCase('en-US')}
+      {Icon && <Icon aria-hidden="true" />}
     </div>
   );
 }

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -3118,35 +3118,9 @@ body {
   font-weight: normal;
 }
 
-/* File icon styles */
-.file-icon-default {
-  color: #782312;
-  background-color: #FFF3EA;
-}
-
-.file-icon-audio {
-  color: #45472F;
-  background-color: #F1F4D7;
-}
-
-.file-icon-application {
-  color: #2F4668;
-  background-color: #ECF1F7;
-}
-
-.file-icon-image {
-  color: #453C7B;
-  background-color: #F1EFF7;
-}
-
-.file-icon-text {
-  color: #4D4438;
+.file-icon {
+  color: #454540;
   background-color: #F5F0E6;
-}
-
-.file-icon-video {
-  color: #45472F;
-  background-color: #F1F4D7;
 }
 
 .tip-component-icon {


### PR DESCRIPTION
The issue with file extensions is that LibreChat would automatically convert many types into "known" types. E.g., all images would be converted from their base type into image/png.

As a result, when we rendered using the mimetype, you might upload a JPEG but then see it labeled as a PNG and go "wait, what?"

Now, we use icons based on the type alone, which is more generic but 100% more likely to be correct.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1788