### PR TITLE
Enable agent sharing button for admins

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentFooter.tsx
+++ b/client/src/components/SidePanel/Agents/AgentFooter.tsx
@@ -116,9 +116,16 @@ export default function AgentFooter({
         </div>
       )}
 
-      {/* Admin settings */}
+      {/* Admin settings (permissions & sharing) - we only let admins share agents atm */}
       {user?.role === SystemRoles.ADMIN && showButtons && (
-        <div className="mt-4 px-4">
+        <div className="mt-4 flex gap-4 px-4">
+          <GenericGrantAccessDialog
+            resourceDbId={agent?._id}
+            resourceId={agent_id}
+            resourceName={agent?.name ?? ''}
+            resourceType={ResourceType.AGENT}
+          />
+
           <AdminSettings />
         </div>
       )}

--- a/client/src/components/SidePanel/Agents/__tests__/AgentFooter.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentFooter.spec.tsx
@@ -343,7 +343,7 @@ describe('AgentFooter', () => {
       mockUseAuthContext.mockReturnValue(createAuthContext(mockUsers.admin));
       const { unmount } = render(<AgentFooter {...defaultProps} />);
       expect(screen.getByTestId('admin-settings')).toBeInTheDocument();
-      expect(screen.queryByTestId('grant-access-dialog-agent')).not.toBeInTheDocument(); // NJ: Removed
+      expect(screen.queryByTestId('grant-access-dialog-agent')).toBeInTheDocument();
 
       // Clean up the first render
       unmount();

--- a/nj/nj-librechat.yaml
+++ b/nj/nj-librechat.yaml
@@ -29,8 +29,8 @@ interface:
   agents:
     use: true
     create: false # Can be overridden with env var INTERFACE_AGENTS
-    share: false
-    public: false
+    share: true
+    public: true
   bookmarks: false
   endpointsMenu: false
   fileCitations: false

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -38,11 +38,14 @@ export async function loadDefaultInterface({
   let agents = interfaceConfig?.agents;
   const agentsEnvVar = getEnvBoolean('INTERFACE_AGENTS');
   if (agentsEnvVar !== undefined) {
+    // Our librechat.yaml doesn't use the boolean, so simplify for now
+    if (typeof agents === 'boolean') {
+      throw Error(`Define the agent perms more specifically, please!`);
+    }
+
     agents = {
-      use: true,
+      ...(agents ?? {}),
       create: agentsEnvVar,
-      share: false,
-      public: false,
     };
   }
 


### PR DESCRIPTION
We want to allow admins to share an agent for all to view, but don't want normal users to be able to share agents.

In order to do this, we have to give admins permission to share, so I've updated the code to represent that.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1781