### PR TITLE
Set S3_URL_EXPIRY_SECONDS to 2 hours

### DIFF
--- a/nj/nj.env.template
+++ b/nj/nj.env.template
@@ -48,6 +48,16 @@ BEDROCK_AWS_MODELS=us.anthropic.claude-sonnet-4-6,us.anthropic.claude-sonnet-4-5
 GUARDRAIL_ID=${GUARDRAIL_ID}
 GUARDRAIL_VERSION=${GUARDRAIL_VERSION}
 
+#===================================================#
+#                        S3                         #
+#===================================================#
+
+# Note: most S3 env vars are dynamically rendered in render-env.yml
+
+# We set the URL expiry to twice the length of the cache refresh - that way, you never end up with an image that
+# is in LibreChat's cache but has already expired.
+S3_URL_EXPIRY_SECONDS=7200
+
 #============#
 # Keys       #
 #============#


### PR DESCRIPTION
By default, it's 2 minutes, which is way too short given that the image cache refreshes at least once every 30 minutes (sometimes 1 hour, if your timing is really unlucky).