### PR TITLE
enable out-of-the-box chat history search

### DIFF
--- a/.github/workflows/render-env.yml
+++ b/.github/workflows/render-env.yml
@@ -72,6 +72,10 @@ jobs:
           export INTERFACE_AGENTS=$([[ "${{ inputs.environment }}" == "dev" ]] && echo true || echo false)
           export INTERFACE_FILE_SEARCH=$([[ "${{ inputs.environment }}" == "dev" ]] && echo true || echo false)
 
+          export SEARCH=$([[ "${{ inputs.environment }}" == "prod" ]] && echo false || echo true)
+          export MEILI_HOST=$([[ "${{ inputs.deploy_kitchensink }}" == "true" ]] && echo "http://meilisearch-kitchensink:7700" || echo "http://meilisearch-dev:7700")
+          export MEILI_MASTER_KEY="${{ secrets.MEILI_MASTER_KEY }}" 
+
           ENV_FILE_NAME=$([[ "${{ inputs.deploy_kitchensink }}" == "true" ]] && echo "librechat.env" || echo "${{ inputs.environment }}.env")
 
           envsubst < nj/nj.env.template > "$ENV_FILE_NAME"

--- a/client/src/nj/utils/tests/constRecoilState.spec.tsx
+++ b/client/src/nj/utils/tests/constRecoilState.spec.tsx
@@ -75,37 +75,4 @@ describe('constRecoilState Tests', () => {
     fireEvent.click(button);
     expect(button).toHaveAttribute('title', 'Recoil Value=67');
   });
-
-  describe('Locked states', () => {
-    test('search is locked to disabled', () => {
-      const defaultState = {
-        enabled: false,
-        query: '',
-        debouncedQuery: '',
-        isSearching: false,
-        isTyping: false,
-      };
-
-      const clickState = {
-        enabled: true,
-        query: 'hello',
-        debouncedQuery: 'hello',
-        isSearching: true,
-        isTyping: true,
-      };
-
-      render(
-        <RecoilRoot>
-          <TestRecoilState recoilState={store.search} clickState={clickState} />
-        </RecoilRoot>,
-      );
-
-      const button = screen.getByTestId('changeRecoilState');
-      expect(button).toHaveAttribute('title', `Recoil Value=${JSON.stringify(defaultState)}`);
-
-      // Click button (which attempts to change the recoil state), but it should remain unchanged
-      fireEvent.click(button);
-      expect(button).toHaveAttribute('title', `Recoil Value=${JSON.stringify(defaultState)}`);
-    });
-  });
 });

--- a/client/src/store/search.ts
+++ b/client/src/store/search.ts
@@ -1,5 +1,4 @@
 import { atom } from 'recoil';
-import { constRecoilStateOpts } from '~/nj/utils/constRecoilState';
 
 export type SearchState = {
   enabled: boolean | null;
@@ -9,11 +8,10 @@ export type SearchState = {
   isTyping: boolean;
 };
 
-// NJ: Disable the search bar until we actually support search (via Meili)
-export const search = constRecoilStateOpts<SearchState>({
+export const search = atom<SearchState>({
   key: 'search',
   default: {
-    enabled: false,
+    enabled: null,
     query: '',
     debouncedQuery: '',
     isSearching: false,

--- a/nj/nj.env.template
+++ b/nj/nj.env.template
@@ -67,7 +67,9 @@ CREDS_IV=0dee71d93a4cd7109fdd7c824c6c9f88
 #                      Search                      #
 #==================================================#
 
-SEARCH=false
+SEARCH=${SEARCH}
+MEILI_HOST=${MEILI_HOST}
+MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
 
 #========================#
 # Registration and Login #


### PR DESCRIPTION
## Description
This PR implements chat history search and ships it out of the box. We will customize, as needed, after we've QA'd on dev/kitchensink.

## Ticket 
Refers to [Search within chat history](https://github.com/newjersey/innovation-platform-pm/issues/1729)

## Steps to Test
1. Check out this branch and run the locally. 
2. **Testing when search term in chat history:**
   - Enter a search term that exists in your chat history (either in the conversation title or message content).
   - Verify that chat history filters correctly.
3. **Testing when search term is not in chat history:**
   - Enter a search term that does **NOT** exist in your chat history.
   - Verify that there are no results (no chats return) and  `Nothing found` appears in chat view.     

## Notes
- Bitwarden: updated local `.env`. 
- Added `MEILI_MASTER_KEY` secret to GitHub.
- In a follow up PR: We'll add Meilisearch to our dev Docker setup

After:

https://github.com/user-attachments/assets/2fbc22b8-1ed9-49c4-a79d-094484717357




