### PR TITLE
"Version history" button now opens the version history

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentFooter.tsx
+++ b/client/src/components/SidePanel/Agents/AgentFooter.tsx
@@ -103,7 +103,10 @@ export default function AgentFooter({
       {/* Advanced settings */}
       {showButtons && (
         <div data-testid="advanced-button">
-          <NewJerseyPanelButton label="Advanced settings" setActivePanel={setActivePanel} />
+          <NewJerseyPanelButton
+            label="Advanced settings"
+            onClick={() => setActivePanel(Panel.advanced)}
+          />
           <hr />
         </div>
       )}
@@ -111,7 +114,10 @@ export default function AgentFooter({
       {/* Version history */}
       {showButtons && agent_id && (
         <div data-testid="version-button">
-          <NewJerseyPanelButton label="Version history" setActivePanel={setActivePanel} />
+          <NewJerseyPanelButton
+            label="Version history"
+            onClick={() => setActivePanel(Panel.version)}
+          />
           <hr />
         </div>
       )}

--- a/client/src/nj/components/NewJerseyPanelButton.tsx
+++ b/client/src/nj/components/NewJerseyPanelButton.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { ChevronRight } from 'lucide-react';
-import { Panel } from '~/common';
 
 export default function NewJerseyPanelButton({
   label,
-  setActivePanel,
+  onClick,
 }: {
   label: string;
-  setActivePanel: (panel: Panel) => void;
+  onClick: () => void;
 }) {
   return (
     <button
       type="button"
-      onClick={() => setActivePanel(Panel.advanced)}
+      onClick={onClick}
       className="flex w-full items-center justify-between bg-surface-tertiary px-3 py-4 text-left hover:bg-[#E6E6E2]"
     >
       <span className="text-token-text-primary text-sm font-semibold">{label}</span>


### PR DESCRIPTION
A hardcoded value caused sadness, of course! Now it's fully dynamic so "advanced settings" goes to advanced settings and "version history" goes to version history.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1803