### PR TITLE
Added "duplicate & edit" button to agent builder

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable i18next/no-literal-string */
+/* ^ We're not worried about i18n for this app ^ */
+
 import React, { useMemo, useCallback, useRef, useState } from 'react';
 import { Button, useToastContext } from '@librechat/client';
 import { useWatch, useForm, FormProvider } from 'react-hook-form';
@@ -21,10 +24,12 @@ import {
   useGetExpandedAgentByIdQuery,
   useUploadAgentAvatarMutation,
 } from '~/data-provider';
+import AgentBuilderHeader from '~/nj/components/Agents/AgentBuilderHeader';
 import { createProviderOption, getDefaultAgentFormValues } from '~/utils';
 import { useResourcePermissions } from '~/hooks/useResourcePermissions';
 import { useSelectAgent, useLocalize, useAuthContext } from '~/hooks';
 import { useAgentPanelContext } from '~/Providers/AgentPanelContext';
+import { useDuplicateAgentMutation } from '~/data-provider';
 import AgentPanelSkeleton from './AgentPanelSkeleton';
 import AdvancedPanel from './Advanced/AdvancedPanel';
 import { Panel, isEphemeralAgent } from '~/common';
@@ -32,7 +37,6 @@ import AgentConfig from './AgentConfig';
 import AgentSelect from './AgentSelect';
 import AgentFooter from './AgentFooter';
 import ModelPanel from './ModelPanel';
-import AgentBuilderHeader from '~/nj/components/Agents/AgentBuilderHeader';
 
 /* Helpers */
 function getUpdateToastMessage(
@@ -248,6 +252,28 @@ export default function AgentPanel() {
     defaultValues: getDefaultAgentFormValues(),
     mode: 'onChange',
   });
+
+  const duplicateAgent = useDuplicateAgentMutation({
+    onSuccess: ({ agent }) => {
+      showToast({
+        message: localize('com_ui_agent_duplicated'),
+        status: 'success',
+      });
+
+      setCurrentAgentId(agent.id);
+    },
+    onError: (error) => {
+      console.error(error);
+      showToast({
+        message: localize('com_ui_agent_duplicate_error'),
+        status: 'error',
+      });
+    },
+  });
+
+  const handleDuplicate = () => {
+    duplicateAgent.mutate({ agent_id });
+  };
 
   const {
     control,
@@ -552,6 +578,10 @@ export default function AgentPanel() {
                   {localize('com_agents_not_available')}
                 </h2>
                 <p className="text-token-text-secondary">{localize('com_agents_no_access')}</p>
+                {/* NJ: Give users a way to edit their own copy of an agent */}
+                <Button variant="submit" className="mt-4" onClick={handleDuplicate}>
+                  Duplicate & edit<span className="sr-only"> agent {agentQuery?.data?.name}</span>
+                </Button>
               </div>
             </div>
           )}


### PR DESCRIPTION
When you are viewing an agent you can't edit in the agent builder, we now provide a quick way to duplicate the agent & edit your own personalized version of it.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1794

Looks like this (clicking on the button duplicates the agent & sets the currently edited agent to the duplicate):

<img width="435" height="475" alt="Screenshot 2026-06-11 at 10 00 56 AM" src="https://github.com/user-attachments/assets/f915259b-1546-44b8-a739-a5152bc94f88" />

_(Note: design decided "duplicate & edit" is a better word, but I don't want to update the screenshot, please don't sue me)_