### PR TITLE
Made agent landing page more agent-y

### DIFF
--- a/client/src/components/Chat/Landing.tsx
+++ b/client/src/components/Chat/Landing.tsx
@@ -1,13 +1,10 @@
-import { useMemo, useCallback, useState, useEffect, useRef } from 'react';
-import { easings } from '@react-spring/web';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { EModelEndpoint } from 'librechat-data-provider';
-import { BirthdayIcon, TooltipAnchor, SplitText } from '@librechat/client';
-import { useChatContext, useAgentsMapContext, useAssistantsMapContext } from '~/Providers';
+import { useAgentsMapContext, useAssistantsMapContext, useChatContext } from '~/Providers';
 import { useGetEndpointsQuery, useGetStartupConfig } from '~/data-provider';
-import ConvoIcon from '~/components/Endpoints/ConvoIcon';
-import { useLocalize, useAuthContext } from '~/hooks';
-import { getIconEndpoint, getEntity } from '~/utils';
 import { NewJerseyLanding } from '~/nj/components/NewJerseyLanding';
+import { useAuthContext, useLocalize } from '~/hooks';
+import { getEntity, getIconEndpoint } from '~/utils';
 
 const containerClassName =
   'shadow-stroke relative flex h-full items-center justify-center rounded-full bg-white dark:bg-presentation dark:text-white text-black dark:after:shadow-none ';
@@ -137,6 +134,21 @@ export default function Landing({ centerFormOnLanding }: { centerFormOnLanding: 
     typeof startupConfig?.interface?.customWelcome === 'string'
       ? getGreeting()
       : getGreeting() + (user?.name ? ', ' + user.name : '');
+
+  // NJ: We normally fully customize the landing page, but if you're talking to an agent,
+  // we want to make it more obvious what's going on, so we partially revert to normal layout
+  if (isAgent && name) {
+    return (
+      <div
+        className={`flex h-full transform-gpu flex-col items-center justify-center pt-10 transition-all duration-200 ${centerFormOnLanding ? 'max-h-full sm:max-h-0' : 'max-h-full'}`}
+      >
+        <div className="flex flex-col items-center gap-0 p-2 px-2.5 md:max-w-3xl xl:max-w-4xl">
+          <h2 className="mb-3 text-center text-3xl font-bold">{name}</h2>
+          {description && <p className="text-center text-sm text-text-secondary">{description}</p>}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/client/src/hooks/Input/useTextarea.ts
+++ b/client/src/hooks/Input/useTextarea.ts
@@ -107,7 +107,10 @@ export default function useTextarea({
           ? getEntityName({ name: entityName, isAgent, localize })
           : getSender(conversation as TEndpointOption);
 
-      return 'What would you like to accomplish today?'; // NJ: Custom prompt placeholder
+      // NJ: Custom prompt placeholder, if not an agent
+      if (!isAgent) {
+        return 'What would you like to accomplish today?';
+      }
 
       return `${localize('com_endpoint_message_new', {
         0: sender ? sender : localize('com_endpoint_ai'),


### PR DESCRIPTION
The landing page showed almost nothing about an agent you're using if you selected it. Now, it's very obvious when you're using an agent because:

1. The old landing page content (welcome to NJ AIA, blurb, info accordion) is all gone.

2. The agent name & description is front and center.

3. The placeholder text prompts you to talk to the agent.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1806

------

Before:

<img width="738" height="443" alt="Screenshot 2026-06-11 at 3 14 21 PM" src="https://github.com/user-attachments/assets/826a9af9-1cfa-4eb6-8d4e-b7602329e95a" />

After:

<img width="735" height="442" alt="Screenshot 2026-06-11 at 3 11 42 PM" src="https://github.com/user-attachments/assets/b5a5f230-f468-4fe8-8578-5d06642376ad" />

