### PR TITLE
fix: don't reset agent builder after file upload

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentSelect.tsx
+++ b/client/src/components/SidePanel/Agents/AgentSelect.tsx
@@ -44,7 +44,7 @@ function AgentSelect({
   );
 
   const resetAgentForm = useCallback(
-    (fullAgent: Agent) => {
+    (fullAgent: Agent, options?: Record<string, boolean>) => {
       const isGlobal = fullAgent.isPublic ?? false;
       const update = {
         ...fullAgent,
@@ -149,7 +149,7 @@ function AgentSelect({
         }
       });
 
-      reset(formValues);
+      reset(formValues, options);
     },
     [reset],
   );
@@ -180,7 +180,7 @@ function AgentSelect({
 
   useEffect(() => {
     if (agentQuery.data && agentQuery.isSuccess) {
-      resetAgentForm(agentQuery.data);
+      resetAgentForm(agentQuery.data, { keepDirtyValues: true });
     }
   }, [agentQuery.data, agentQuery.isSuccess, resetAgentForm]);
 


### PR DESCRIPTION
If you edited one of the form fields in the agent builder (such as instructions), then uploaded a file, the form field would get reset due to `resetAgentForm()` being called every time the `agentQuery` updates.

Now, we pass the `keepDirtyValues` option when that happens, which keeps the other form fields as they were before the file was uploaded.

Note that this preserves the behavior wherein changing the agent resets the whole form (as it should).

Part of https://github.com/newjersey/innovation-platform-pm/issues/1769