### PR TITLE
configure Meilisearch for dev

### DIFF
--- a/.github/workflows/render-env.yml
+++ b/.github/workflows/render-env.yml
@@ -72,7 +72,8 @@ jobs:
           export INTERFACE_AGENTS=$([[ "${{ inputs.environment }}" == "dev" ]] && echo true || echo false)
 
           export SEARCH=$([[ "${{ inputs.environment }}" == "prod" ]] && echo false || echo true)
-          export MEILI_HOST=$([[ "${{ inputs.deploy_kitchensink }}" == "true" ]] && echo "http://meilisearch.kitchensink:7700" || echo "http://meilisearch.dev:7700")
+          export MEILI_NO_ANALYTICS=true
+          export MEILI_HOST=$([[ "${{ inputs.deploy_kitchensink }}" == "true" ]] && echo "http://meilisearch.kitchensink:7700" || echo "http://meilisearch.internal:7700")
           export MEILI_MASTER_KEY="${{ secrets.MEILI_MASTER_KEY }}" 
 
           ENV_FILE_NAME=$([[ "${{ inputs.deploy_kitchensink }}" == "true" ]] && echo "librechat.env" || echo "${{ inputs.environment }}.env")

--- a/nj/infra/lib/ecs-stack.ts
+++ b/nj/infra/lib/ecs-stack.ts
@@ -62,18 +62,37 @@ export class EcsStack extends cdk.Stack {
       mongoSecret.grantRead(commonExecRole);
     }
 
-    const librechatService = this.CreateLibrechatService(props, cluster, commonExecRole, isProd, mongoSecret);
+    const librechatService = this.CreateLibrechatService(
+      props,
+      cluster,
+      commonExecRole,
+      isProd,
+      mongoSecret,
+    );
     this.listener = librechatService.listener;
     this.loadBalancer = librechatService.loadBalancer;
     this.service = librechatService;
 
     librechatService.service.enableCloudMap({ name: 'librechat' });
 
-    const ragApiService = this.CreateRagApiService(props, commonExecRole, cluster, librechatService);
+    const ragApiService = this.CreateRagApiService(
+      props,
+      commonExecRole,
+      cluster,
+      librechatService,
+    );
 
     if (!isProd) {
-      this.CreateDatabaseSidecars(props, commonExecRole, vpc, cluster, librechatService, mongoSecret);
+      this.CreateDatabaseSidecars(
+        props,
+        commonExecRole,
+        vpc,
+        cluster,
+        librechatService,
+        mongoSecret,
+      );
       this.CreateAdminPanelService(props, commonExecRole, vpc, cluster, librechatService);
+      this.CreateMeilisearchService(props, commonExecRole, vpc, cluster, librechatService);
     }
   }
 
@@ -203,7 +222,7 @@ export class EcsStack extends cdk.Stack {
       HOST: '0.0.0.0',
       ADMIN_PANEL_URL: `https://${props.envVars.domainName}/admin`,
       LOG_LEVEL: 'info',
-      MEILI_HOST: 'http://rag_api.internal:7700',
+      MEILI_HOST: 'http://meilisearch.internal:7700',
       RAG_API_URL: 'http://rag_api.internal:8000',
       CONFIG_PATH: '/app/nj/nj-librechat.yaml',
       AWS_BUCKET_NAME: this.s3Bucket.bucketName,
@@ -219,7 +238,9 @@ export class EcsStack extends cdk.Stack {
       REDIS_USE_ALTERNATIVE_DNS_LOOKUP: 'true',
       REDIS_CLUSTER_SAFE_DELETE: 'true',
 
-      ...(!isProd && !mongoSecret ? { MONGO_URI: 'mongodb://mongodb.internal:27017/LibreChat' } : {}),
+      ...(!isProd && !mongoSecret
+        ? { MONGO_URI: 'mongodb://mongodb.internal:27017/LibreChat' }
+        : {}),
       ...(!isProd && props.rdsEndpoint && props.rdsPort
         ? {
             POSTGRES_HOST: props.rdsEndpoint,
@@ -230,7 +251,9 @@ export class EcsStack extends cdk.Stack {
 
     const envSecrets: Record<string, ecs.Secret> = {
       ...(isProd ? { MONGO_URI: ecs.Secret.fromSecretsManager(docdbSecret, 'uri') } : {}),
-      ...(!isProd && mongoSecret ? { MONGO_URI: ecs.Secret.fromSecretsManager(mongoSecret, 'uri') } : {}),
+      ...(!isProd && mongoSecret
+        ? { MONGO_URI: ecs.Secret.fromSecretsManager(mongoSecret, 'uri') }
+        : {}),
       ...(!isProd && props.rdsSecret
         ? {
             POSTGRES_USER: ecs.Secret.fromSecretsManager(props.rdsSecret, 'username'),
@@ -437,7 +460,6 @@ export class EcsStack extends cdk.Stack {
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
     });
 
-
     // Allow RAG API to connect to RDS
     if (props.rdsSecurityGroup && props.rdsPort) {
       ragApiService.connections.allowTo(
@@ -485,10 +507,14 @@ export class EcsStack extends cdk.Stack {
       props.adminPanelSessionSecretArn,
     );
     sessionSecret.grantRead(commonExecRole);
-    commonExecRole.addToPolicy(new iam.PolicyStatement({
-      actions: ['secretsmanager:GetSecretValue'],
-      resources: [`arn:aws:secretsmanager:${this.region}:${this.account}:secret:ai-assistant/admin-panel/session-secret-*`],
-    }));
+    commonExecRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['secretsmanager:GetSecretValue'],
+        resources: [
+          `arn:aws:secretsmanager:${this.region}:${this.account}:secret:ai-assistant/admin-panel/session-secret-*`,
+        ],
+      }),
+    );
 
     taskDef.addContainer('librechat-admin-panel', {
       image: ecs.ContainerImage.fromRegistry(props.librechatAdminImage),
@@ -566,6 +592,73 @@ export class EcsStack extends cdk.Stack {
     });
 
     new cdk.CfnOutput(this, 'AdminPanelImageUri', { value: props.librechatAdminImage });
+  }
+
+  private CreateMeilisearchService(
+    props: EcsServicesProps,
+    commonExecRole: iam.Role,
+    vpc: ec2.IVpc,
+    cluster: ecs.Cluster,
+    librechatService: ecsPatterns.ApplicationLoadBalancedFargateService,
+  ): ecs.FargateService {
+    const meiliFiles = new efs.FileSystem(this, 'MeiliFs', {
+      vpc,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      encrypted: true,
+    });
+    const meiliTaskDef = new ecs.FargateTaskDefinition(this, 'MeilisearchTaskDef', {
+      cpu: 256,
+      memoryLimitMiB: 512,
+      executionRole: commonExecRole,
+    });
+
+    meiliTaskDef.addVolume({
+      name: 'meiliData',
+      efsVolumeConfiguration: {
+        fileSystemId: meiliFiles.fileSystemId,
+        transitEncryption: 'ENABLED',
+      },
+    });
+
+    const meiliContainer = meiliTaskDef.addContainer('meilisearch', {
+      image: ecs.ContainerImage.fromRegistry('getmeili/meilisearch:v1.35.1'),
+      logging: ecs.LogDrivers.awsLogs({ streamPrefix: 'meilisearch' }),
+      portMappings: [{ containerPort: 7700 }],
+      environmentFiles: [
+        ecs.EnvironmentFile.fromBucket(
+          s3.Bucket.fromBucketArn(this, 'EnvFilesBucket', 'arn:aws:s3:::nj-librechat-env-files'),
+          `${props.envVars.env}.env`,
+        ),
+      ],
+    });
+
+    meiliContainer.addMountPoints({
+      sourceVolume: 'meiliData',
+      containerPath: '/meili_data',
+      readOnly: false,
+    });
+
+    const meiliService = new ecs.FargateService(this, 'MeilisearchService', {
+      cluster,
+      taskDefinition: meiliTaskDef,
+      desiredCount: 1,
+      enableExecuteCommand: true,
+      cloudMapOptions: {
+        name: 'meilisearch',
+      },
+      vpcSubnets: {
+        subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+      },
+    });
+
+    meiliFiles.connections.allowDefaultPortFrom(meiliService);
+
+    meiliService.connections.allowFrom(
+      librechatService.service,
+      ec2.Port.tcp(7700),
+      'Librechat to Meilisearch',
+    );
+    return meiliService;
   }
 
   private CreateFileS3Bucket() {

--- a/nj/infra/lib/ecs-stack.ts
+++ b/nj/infra/lib/ecs-stack.ts
@@ -42,6 +42,12 @@ export class EcsStack extends cdk.Stack {
   public readonly s3Bucket: s3.Bucket;
   public mongoService?: ecs.FargateService;
 
+  private readonly envFilesBucket = s3.Bucket.fromBucketArn(
+    this,
+    'EnvFilesBucket',
+    'arn:aws:s3:::nj-librechat-env-files',
+  );
+
   constructor(scope: Construct, id: string, props: EcsServicesProps) {
     super(scope, id, props);
     const vpc = ec2.Vpc.fromLookup(this, 'ExistingVpc', {
@@ -270,8 +276,7 @@ export class EcsStack extends cdk.Stack {
       secrets: envSecrets,
       environmentFiles: [
         ecs.EnvironmentFile.fromBucket(
-          s3.Bucket.fromBucketArn(this, 'EnvFilesBucket', 'arn:aws:s3:::nj-librechat-env-files'),
-          `${props.envVars.env}.env`,
+          s3.Bucket.fromBucketArn(this.envFilesBucket, `${props.envVars.env}.env`),
         ),
       ],
       portMappings: [{ containerPort: 3080 }],
@@ -620,14 +625,15 @@ export class EcsStack extends cdk.Stack {
       },
     });
 
+    const meiliImage = `${this.account}.dkr.ecr.${this.region}.amazonaws.com/newjersey/meilisearch:v1.35.1`;
+
     const meiliContainer = meiliTaskDef.addContainer('meilisearch', {
-      image: ecs.ContainerImage.fromRegistry('getmeili/meilisearch:v1.35.1'),
+      image: ecs.ContainerImage.fromRegistry(meiliImage),
       logging: ecs.LogDrivers.awsLogs({ streamPrefix: 'meilisearch' }),
       portMappings: [{ containerPort: 7700 }],
       environmentFiles: [
         ecs.EnvironmentFile.fromBucket(
-          s3.Bucket.fromBucketArn(this, 'EnvFilesBucket', 'arn:aws:s3:::nj-librechat-env-files'),
-          `${props.envVars.env}.env`,
+          s3.Bucket.fromBucketArn(this.envFilesBucket, `${props.envVars.env}.env`),
         ),
       ],
     });

--- a/nj/infra/lib/kitchensink-stack.ts
+++ b/nj/infra/lib/kitchensink-stack.ts
@@ -59,7 +59,12 @@ export class KitchenSinkStack extends cdk.Stack {
     const vectorDbService = this.createVectorDbService(vpc, cluster, execRole);
     const meiliService = this.createMeiliSearchService(vpc, cluster, execRole, envBucket);
     const ollamaService = this.createOllamaService(vpc, cluster, execRole);
-    const ragApiService = this.createRagApiService(cluster, execRole, envBucket, props.ragApiJwtSecretArn);
+    const ragApiService = this.createRagApiService(
+      cluster,
+      execRole,
+      envBucket,
+      props.ragApiJwtSecretArn,
+    );
     const librechatService = this.createLibrechatService(
       vpc,
       cluster,
@@ -400,7 +405,11 @@ export class KitchenSinkStack extends cdk.Stack {
       }),
     );
 
-    const jwtSecret = secrets.Secret.fromSecretCompleteArn(this, 'RagApiJwtSecret', ragApiJwtSecretArn);
+    const jwtSecret = secrets.Secret.fromSecretCompleteArn(
+      this,
+      'RagApiJwtSecret',
+      ragApiJwtSecretArn,
+    );
     jwtSecret.grantRead(execRole);
 
     const taskDef = new ecs.FargateTaskDefinition(this, 'RagApiTaskDef', {

--- a/nj/nj.env.template
+++ b/nj/nj.env.template
@@ -78,6 +78,7 @@ CREDS_IV=0dee71d93a4cd7109fdd7c824c6c9f88
 #==================================================#
 
 SEARCH=${SEARCH}
+MEILI_NO_ANALYTICS=${MEILI_NO_ANALYTICS}
 MEILI_HOST=${MEILI_HOST}
 MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
 


### PR DESCRIPTION
## Description
This PR provisions Meilisearch in the dev ECS environment to ensure chat history search functionality works.

## Ticket 
Refers to [Search within chat history](https://github.com/newjersey/innovation-platform-pm/issues/1729)

## Approach
- Adds an internal Meilisearch service in the dev ECS stack
- Updates environment variables to enable search
- Ensures ECS networking allows Librechat to communicate with Meilisearch on port 7700

## Notes
- Kitchensink: already enabled
- Prod: not yet enabled