### PR TITLE
fix: update env file S3 bucket value for environmentFiles

### DIFF
--- a/nj/infra/lib/ecs-stack.ts
+++ b/nj/infra/lib/ecs-stack.ts
@@ -276,8 +276,8 @@ export class EcsStack extends cdk.Stack {
       secrets: envSecrets,
       environmentFiles: [
         ecs.EnvironmentFile.fromBucket(
-          s3.Bucket.fromBucketArn(this.envFilesBucket, `${props.envVars.env}.env`),
-        ),
+          this.envFilesBucket, 
+          `${props.envVars.env}.env`),
       ],
       portMappings: [{ containerPort: 3080 }],
       command: ['npm', 'run', 'backend'],
@@ -633,8 +633,8 @@ export class EcsStack extends cdk.Stack {
       portMappings: [{ containerPort: 7700 }],
       environmentFiles: [
         ecs.EnvironmentFile.fromBucket(
-          s3.Bucket.fromBucketArn(this.envFilesBucket, `${props.envVars.env}.env`),
-        ),
+          this.envFilesBucket, 
+          `${props.envVars.env}.env`),
       ],
     });
 


### PR DESCRIPTION
## Description 

This PR fixes the [TS error](https://github.com/newjersey/nj-ai-assistant/actions/runs/27571615383/job/81509300947) that rendered when I ran the `Deploy AI Assistant Infrastructure` workflow to deploy the new CDK/IaC for Meilisearch on dev.