### PR TITLE
Removed duplicative "new chat" button

### DIFF
--- a/client/src/components/Conversations/Conversations.tsx
+++ b/client/src/components/Conversations/Conversations.tsx
@@ -1,20 +1,20 @@
-import { useMemo, memo, type FC, useCallback, useEffect, useRef } from 'react';
+import { type FC, memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import throttle from 'lodash/throttle';
 import { useRecoilValue } from 'recoil';
 import { ChevronDown } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
 import { useQueryClient } from '@tanstack/react-query';
-import { List, AutoSizer, CellMeasurer, CellMeasurerCache } from 'react-virtualized';
-import { Spinner, TooltipAnchor, NewChatIcon, useMediaQuery } from '@librechat/client';
+import { Spinner, useMediaQuery } from '@librechat/client';
+import { AutoSizer, CellMeasurer, CellMeasurerCache, List } from 'react-virtualized';
 import type { TConversation } from 'librechat-data-provider';
 import {
-  useLocalize,
   TranslationKeys,
   useFavorites,
-  useShowMarketplace,
+  useLocalize,
   useNewConvo,
+  useShowMarketplace,
 } from '~/hooks';
-import { groupConversationsByDate, clearMessagesCache, cn } from '~/utils';
+import { clearMessagesCache, cn, groupConversationsByDate } from '~/utils';
 import FavoritesList from '~/components/Nav/Favorites/FavoritesList';
 import { useActiveJobs } from '~/data-provider';
 import Convo from './Convo';
@@ -118,6 +118,7 @@ const ChatsHeader: FC<ChatsHeaderProps> = memo(({ isExpanded, onToggle }) => {
           aria-hidden="true"
         />
       </button>
+      {/* NJ: removed duplicative "new chat" button; it exists at all times in the sidebar already
       <TooltipAnchor
         description={localize('com_ui_new_chat')}
         render={
@@ -131,6 +132,7 @@ const ChatsHeader: FC<ChatsHeaderProps> = memo(({ isExpanded, onToggle }) => {
           </button>
         }
       />
+       */}
     </div>
   );
 });


### PR DESCRIPTION
There's a "new chat" button that lives at all times in the sidebar; we don't need to duplicate this (so close to the current one, too).

Part of https://github.com/newjersey/innovation-platform-pm/issues/1832

Before:

<img width="373" height="229" alt="Screenshot 2026-06-16 at 1 27 17 PM" src="https://github.com/user-attachments/assets/035ccfe0-8340-4243-ab83-ac80e767f3c6" />

After:

<img width="376" height="229" alt="Screenshot 2026-06-16 at 1 27 06 PM" src="https://github.com/user-attachments/assets/cf5a07c1-944f-4410-b75a-f2d20bd12eb6" />
