### PR TITLE
Updated Button styling for New Jersey colors

### DIFF
--- a/packages/client/src/components/Button.tsx
+++ b/packages/client/src/components/Button.tsx
@@ -28,13 +28,12 @@ const buttonVariants: (
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
           'bg-surface-destructive text-destructive-foreground hover:bg-surface-destructive-hover',
-        outline:
-          'text-text-primary border border-border-light bg-transparent hover:bg-accent hover:text-accent-foreground',
+        outline: 'text-jersey-blue bg-transparent hover:underline',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-surface-hover hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
         // hardcoded text color because of WCAG contrast issues (text-white)
-        submit: 'bg-surface-submit text-white hover:bg-surface-submit-hover',
+        submit: 'bg-jersey-button text-white hover:bg-jersey-button-hover',
       },
       size: {
         default: 'h-10 px-4 py-2',


### PR DESCRIPTION
We had previously updated the v1 version of buttons in the app (the ones that use CSS classes like `.btn`). Now we're updating the styling for buttons that use the v2 buttons, aka `Button`.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1831

Before:

<img width="538" height="247" alt="Screenshot 2026-06-16 at 1 43 07 PM" src="https://github.com/user-attachments/assets/3ce6f415-23f3-48aa-b394-8c7420e6e0be" />

After:

<img width="538" height="247" alt="Screenshot 2026-06-16 at 1 42 48 PM" src="https://github.com/user-attachments/assets/ccb76669-eb0e-4bb3-bba1-f51324b6d40a" />
