### PR TITLE
Allow duplicating agents users can view

### DIFF
--- a/api/server/routes/agents/v1.js
+++ b/api/server/routes/agents/v1.js
@@ -108,7 +108,7 @@ router.post(
   '/:id/duplicate',
   checkAgentCreate,
   canAccessAgentResource({
-    requiredPermission: PermissionBits.EDIT,
+    requiredPermission: PermissionBits.VIEW, // NJ: Allow duplicating agents users can view, so they can customize them
     resourceIdParam: 'id',
   }),
   v1.duplicateAgent,


### PR DESCRIPTION
We purposefully want to allow this behavior. We don't want users to be able to edit globally shared agents, but we do want them to be able to customize them. Duplicate & edit is our answer to that problem.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1843