### PR TITLE
Fixed agent builder state handling when returning from subpanel

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -518,7 +518,7 @@ export default function AgentPanel() {
         <div className="flex-1">
           {activePanel === Panel.builder && (
             <AgentBuilderHeader
-              agent_id={agent_id}
+              agent_id={agentQuery.isInitialLoading ? undefined : current_agent_id}
               onClickCreateNew={() => {
                 reset(getDefaultAgentFormValues());
                 setCurrentAgentId(undefined);


### PR DESCRIPTION
If you opened, say, "version history" then returned back to the builder, then some weird things might happen (like the version history button disappearing).

It turns out there's some subtle interactions happening and you have to pass the AgentSelect the current_agent_id, not agent_id, or it won't load properly on remount.