### PR TITLE
Focus agent builder sub-panels upon opening

### DIFF
--- a/client/src/components/SidePanel/Agents/Advanced/AdvancedPanel.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/AdvancedPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef, useEffect } from 'react';
 import { ChevronLeft } from 'lucide-react';
 import { AgentCapabilities } from 'librechat-data-provider';
 import { useFormContext, Controller } from 'react-hook-form';
@@ -18,6 +18,12 @@ export default function AdvancedPanel() {
   const currentAgentId = watch('id');
 
   const { agentsConfig, setActivePanel } = useAgentPanelContext();
+
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, []);
   const chainEnabled = useMemo(
     () => agentsConfig?.capabilities.includes(AgentCapabilities.chain) ?? false,
     [agentsConfig],
@@ -28,7 +34,7 @@ export default function AdvancedPanel() {
   );
 
   return (
-    <div className="mb-1 flex w-full flex-col gap-2 text-sm">
+    <div ref={panelRef} tabIndex={-1} className="mb-1 flex w-full flex-col gap-2 text-sm">
       <div className="advanced-panel relative flex flex-col items-center px-16 pt-2 text-center">
         <div className="absolute left-0 top-4">
           <button

--- a/client/src/components/SidePanel/Agents/Version/VersionPanel.tsx
+++ b/client/src/components/SidePanel/Agents/Version/VersionPanel.tsx
@@ -1,8 +1,8 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ChevronLeft } from 'lucide-react';
-import { useCallback, useMemo } from 'react';
 import { useToastContext } from '@librechat/client';
-import { useGetAgentByIdQuery, useRevertAgentVersionMutation } from '~/data-provider';
 import type { AgentWithVersions, VersionContext } from './types';
+import { useGetAgentByIdQuery, useRevertAgentVersionMutation } from '~/data-provider';
 import { isActiveVersion } from './isActiveVersion';
 import { useAgentPanelContext } from '~/Providers';
 import VersionContent from './VersionContent';
@@ -100,6 +100,12 @@ export default function VersionPanel() {
     [versions, versionIds, currentAgent, selectedAgentId, activeVersion],
   );
 
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, []);
+
   const handleRestore = useCallback(
     (displayIndex: number) => {
       const versionWithId = versionIds.find((v) => v.id === displayIndex);
@@ -117,7 +123,11 @@ export default function VersionPanel() {
   );
 
   return (
-    <div className="scrollbar-gutter-stable h-full min-h-[40vh] overflow-auto pb-12 text-sm">
+    <div
+      ref={panelRef}
+      tabIndex={-1}
+      className="scrollbar-gutter-stable h-full min-h-[40vh] overflow-auto pb-12 text-sm"
+    >
       <div className="version-panel relative flex flex-col items-center px-16 py-4 text-center">
         <div className="absolute left-0 top-4">
           <button


### PR DESCRIPTION
We want to make sure that screen readers know that a new panel has opened (and start them off at the container).

However, the panels are not focusable by keyboard; it's only focused for screen readers on open.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1813