### PR TITLE
Fix button focus when returning to agent builder from subpanel

### DIFF
--- a/client/src/Providers/AgentPanelContext.tsx
+++ b/client/src/Providers/AgentPanelContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useMemo } from 'react';
+import React, { createContext, useContext, useState, useMemo, useRef } from 'react';
 import { EModelEndpoint } from 'librechat-data-provider';
 import type { MCP, Action, TPlugin } from 'librechat-data-provider';
 import type { AgentPanelContextType, MCPServerInfo } from '~/common';
@@ -33,6 +33,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
   const [mcps, setMcps] = useState<MCP[] | undefined>(undefined);
   const [action, setAction] = useState<Action | undefined>(undefined);
   const [activePanel, setActivePanel] = useState<Panel>(Panel.builder);
+  const returnFocusRef = useRef<Panel | null>(null);
   const [agent_id, setCurrentAgentId] = useState<string | undefined>(undefined);
   const { availableMCPServers, isLoading, availableMCPServersMap } = useMCPServerManager();
   const { data: startupConfig } = useGetStartupConfig();
@@ -150,6 +151,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
     mcpServersMap,
     setActivePanel,
     endpointsConfig,
+    returnFocusRef,
     setCurrentAgentId,
     availableMCPServers,
     availableMCPServersMap,

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -235,6 +235,8 @@ export type AgentPanelContextType = {
   mcpServersMap: Map<string, MCPServerInfo>;
   availableMCPServers: MCPServerDefinition[];
   availableMCPServersMap: t.MCPServersListResponse | undefined;
+  /** NJ: Identifies which trigger button opened current subpanel for returning focus on back */
+  returnFocusRef: React.MutableRefObject<Panel | null>;
 };
 
 export type AgentModelPanelProps = {

--- a/client/src/components/SidePanel/Agents/AgentFooter.tsx
+++ b/client/src/components/SidePanel/Agents/AgentFooter.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 /* ^ We're not worried about i18n for this app ^ */
 
-import { useCallback } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 import { Globe } from 'lucide-react';
 import { Spinner } from '@librechat/client';
 import { useWatch, useFormContext } from 'react-hook-form';
@@ -21,6 +21,7 @@ import {
 } from '~/hooks';
 import { AgentForm, AgentPanelProps, isEphemeralAgent } from '~/common';
 import NewJerseyPanelButton from '~/nj/components/NewJerseyPanelButton';
+import { useAgentPanelContext } from '~/Providers/AgentPanelContext';
 import { GenericGrantAccessDialog } from '~/components/Sharing';
 import { useUpdateAgentMutation } from '~/data-provider';
 import AdvancedButton from './Advanced/AdvancedButton';
@@ -67,6 +68,25 @@ export default function AgentFooter({
   const { hasPermission: hasRemoteAgentPermission, isLoading: remotePermissionsLoading } =
     useResourcePermissions(ResourceType.REMOTE_AGENT, agent?._id || '');
 
+  // NJ: Used to set focus to correct button after returning from its subpanel
+  // (E.g., click "version history", then go back, refocuses the "version history" button again)
+  const { returnFocusRef } = useAgentPanelContext();
+  const advancedButtonRef = useRef<HTMLButtonElement>(null);
+  const versionButtonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (activePanel !== Panel.builder) {
+      return;
+    }
+    const target = returnFocusRef.current;
+    if (target === Panel.advanced && advancedButtonRef.current) {
+      advancedButtonRef.current.focus();
+      returnFocusRef.current = null;
+    } else if (target === Panel.version && versionButtonRef.current) {
+      versionButtonRef.current.focus();
+      returnFocusRef.current = null;
+    }
+  }, [activePanel, agent_id, returnFocusRef]);
+
   const { onSelect: onSelectAgent } = useSelectAgent();
   const handleSelectAgent = useCallback(() => {
     if (agent_id) {
@@ -106,8 +126,12 @@ export default function AgentFooter({
       {showButtons && (
         <div data-testid="advanced-button">
           <NewJerseyPanelButton
+            ref={advancedButtonRef}
             label="Advanced settings"
-            onClick={() => setActivePanel(Panel.advanced)}
+            onClick={() => {
+              returnFocusRef.current = Panel.advanced;
+              setActivePanel(Panel.advanced);
+            }}
           />
           <hr />
         </div>
@@ -117,8 +141,12 @@ export default function AgentFooter({
       {showButtons && agent_id && (
         <div data-testid="version-button">
           <NewJerseyPanelButton
+            ref={versionButtonRef}
             label="Version history"
-            onClick={() => setActivePanel(Panel.version)}
+            onClick={() => {
+              returnFocusRef.current = Panel.version;
+              setActivePanel(Panel.version);
+            }}
           />
           <hr />
         </div>

--- a/client/src/components/SidePanel/Agents/__tests__/AgentFooter.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentFooter.spec.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { SystemRoles } from 'librechat-data-provider';
 import { render, screen } from '@testing-library/react';
+import type { Agent, AgentCreateParams, ResourceType, TUser } from 'librechat-data-provider';
 import type { UseMutationResult } from '@tanstack/react-query';
 import '@testing-library/jest-dom/extend-expect';
-import type { Agent, AgentCreateParams, TUser, ResourceType } from 'librechat-data-provider';
 import AgentFooter from '../AgentFooter';
 import { Panel } from '~/common';
 
@@ -180,6 +180,10 @@ jest.mock('~/components/Sharing', () => ({
       data-resource-type={resourceType}
     />
   ),
+}));
+
+jest.mock('~/Providers/AgentPanelContext', () => ({
+  useAgentPanelContext: () => ({ returnFocusRef: { current: null } }),
 }));
 
 describe('AgentFooter', () => {

--- a/client/src/nj/components/NewJerseyPanelButton.tsx
+++ b/client/src/nj/components/NewJerseyPanelButton.tsx
@@ -1,21 +1,20 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { ChevronRight } from 'lucide-react';
 
-export default function NewJerseyPanelButton({
-  label,
-  onClick,
-}: {
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex w-full items-center justify-between bg-surface-tertiary px-3 py-4 text-left hover:bg-[#E6E6E2]"
-    >
-      <span className="text-token-text-primary text-sm font-semibold">{label}</span>
-      <ChevronRight className="text-token-text-primary h-4 w-4" aria-hidden />
-    </button>
-  );
-}
+const NewJerseyPanelButton = forwardRef<HTMLButtonElement, { label: string; onClick: () => void }>(
+  function NewJerseyPanelButton({ label, onClick }, ref) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={onClick}
+        className="flex w-full items-center justify-between bg-surface-tertiary px-3 py-4 text-left hover:bg-[#E6E6E2]"
+      >
+        <span className="text-token-text-primary text-sm font-semibold">{label}</span>
+        <ChevronRight className="text-token-text-primary h-4 w-4" aria-hidden />
+      </button>
+    );
+  },
+);
+
+export default NewJerseyPanelButton;


### PR DESCRIPTION
There are subpanels in the agent builder (version history, advanced). When you click on them, it replaces the whole builder with the subpanel.

When you go back to the builder, it would just start focus at the top of the builder again. Now, it refocuses back on the button you clicked in order to get to the subpanel.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1813