### PR TITLE
update @ mention menu copy in chat input field

### DIFF
--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1243,7 +1243,7 @@
   "com_ui_memory_updated": "Updated saved memory",
   "com_ui_memory_updated_items": "Updated Memories",
   "com_ui_memory_would_exceed": "Cannot save - would exceed limit by {{tokens}} tokens. Delete existing memories to make space.",
-  "com_ui_mention": "Mention an endpoint, assistant, or preset to quickly switch to it",
+  "com_ui_mention": "Mention an agent or model to quickly switch to it",
   "com_ui_mermaid": "mermaid",
   "com_ui_mermaid_failed": "Failed to render diagram:",
   "com_ui_mermaid_source": "Source code:",


### PR DESCRIPTION
## Description
This PR updates the `@` mention menu copy in chat input field to "Mention an agent or model to quickly switch to it".
.

## Ticket
Refers to [Update to "@" menu search box copy](https://github.com/newjersey/innovation-platform-pm/issues/1853)

**Before:**
<img width="677" height="255" alt="Screenshot 2026-06-22 at 2 07 56 PM" src="https://github.com/user-attachments/assets/6975562e-f3d4-468f-8ac3-f58b70db996a" />


**After:**
<img width="677" height="255" alt="Screenshot 2026-06-22 at 2 08 08 PM" src="https://github.com/user-attachments/assets/42b5130f-4eb7-4cf3-b490-b3c2316fbad0" />