### PR TITLE
Filter non-default model specs & endpoints from mentions

### DIFF
--- a/client/src/hooks/Input/mentions.spec.ts
+++ b/client/src/hooks/Input/mentions.spec.ts
@@ -15,7 +15,8 @@ describe('filterMentionEndpoints', () => {
     expect(result).toEqual([EModelEndpoint.agents]);
   });
 
-  it('keeps provider endpoints when no model spec allow-list is configured', () => {
+  // NJ: We've invalidated this test with our own behaviors
+  it.skip('keeps provider endpoints when no model spec allow-list is configured', () => {
     const result = filterMentionEndpoints({
       endpoints,
       includedEndpoints: new Set(),
@@ -24,6 +25,17 @@ describe('filterMentionEndpoints', () => {
     });
 
     expect(result).toEqual(endpoints);
+  });
+
+  it('NJ customization: removes all provider endpoints', () => {
+    const result = filterMentionEndpoints({
+      endpoints,
+      includedEndpoints: new Set(),
+      includeAssistants: true,
+      hasAgentAccess: true,
+    });
+
+    expect(result).toEqual([EModelEndpoint.agents]);
   });
 
   it('excludes agents when the user lacks agent access', () => {
@@ -45,6 +57,6 @@ describe('filterMentionEndpoints', () => {
       hasAgentAccess: true,
     });
 
-    expect(result).toEqual([EModelEndpoint.openAI]);
+    expect(result).toEqual([]);
   });
 });

--- a/client/src/hooks/Input/mentions.ts
+++ b/client/src/hooks/Input/mentions.ts
@@ -1,5 +1,14 @@
 import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
 
+const EXCLUDED_ENDPOINTS = new Set([
+  EModelEndpoint.azureOpenAI,
+  EModelEndpoint.openAI,
+  EModelEndpoint.google,
+  EModelEndpoint.anthropic,
+  EModelEndpoint.custom,
+  EModelEndpoint.bedrock,
+]);
+
 export function filterMentionEndpoints({
   endpoints,
   includedEndpoints,
@@ -19,6 +28,11 @@ export function filterMentionEndpoints({
     }
 
     if (isAgentsEndpoint(endpoint) && !hasAgentAccess) {
+      return false;
+    }
+
+    // NJ: We want to exclude endpoints from our mentions, only allowing agents & model specs
+    if (EXCLUDED_ENDPOINTS.has(endpoint as EModelEndpoint)) {
       return false;
     }
 

--- a/client/src/hooks/Input/useMentions.ts
+++ b/client/src/hooks/Input/useMentions.ts
@@ -165,6 +165,10 @@ export default function useMentions({
       if (spec.preset?.endpoint === EModelEndpoint.agents && spec.preset?.agent_id) {
         return spec.preset.agent_id in agentsMap;
       }
+      // NJ: Only render default model spec (for now)
+      if (!spec.default) {
+        return false;
+      }
       /** Keep non-agent modelSpecs */
       return true;
     });


### PR DESCRIPTION
When chatting, you can use the '@' symbol to "mention" a model or agent. However, we don't want people to be able to pick anything besides the default model spec or an agent.

Now, we explicitly filter out generic endpoints + non-default model specs.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1860