### PR TITLE
hide copy link in agent library

### DIFF
--- a/client/src/components/Agents/AgentDetailContent.tsx
+++ b/client/src/components/Agents/AgentDetailContent.tsx
@@ -196,6 +196,8 @@ const AgentDetailContent: React.FC<AgentDetailContentProps> = ({ agent }) => {
         >
           {isFavorite ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
         </Button>
+
+        {/* NJ: We don't want users to share agents ATM
         <Button
           variant="outline"
           size="icon"
@@ -205,6 +207,8 @@ const AgentDetailContent: React.FC<AgentDetailContentProps> = ({ agent }) => {
         >
           <Link className="h-4 w-4" aria-hidden="true" />
         </Button>
+        */}
+
         {/* NJ: Give users a way to edit their own copy of an agent */}
         <Button variant="outline" onClick={handleDuplicate} disabled={!agent}>
           Duplicate<span className="sr-only"> agent {agent?.name}</span>

--- a/nj/nj-librechat.yaml
+++ b/nj/nj-librechat.yaml
@@ -29,7 +29,7 @@ interface:
   agents:
     use: true
     create: false # Can be overridden with env var INTERFACE_AGENTS
-    share: true
+    share: false # in addition to hiding the copy link, we are setting share to false
     public: true
   bookmarks: false
   endpointsMenu: false


### PR DESCRIPTION
## Description
This PR hides the copy link in the Agent Library 

## Ticket
Refers to [Hide copy link in Agent Library](https://github.com/newjersey/innovation-platform-pm/issues/1866)

**Before**
<img width="553" height="435" alt="image" src="https://github.com/user-attachments/assets/74b87116-0844-4d1e-89df-189aa235c7ec" />

**After**
<img width="405" height="295" alt="Screenshot 2026-06-23 at 10 40 47 AM" src="https://github.com/user-attachments/assets/8f752a08-f7ec-4019-8dbd-38f8f46bcfb3" />
