### PR TITLE
fix: moved `enabled` after `config` expansion in useGetAgentByIdQuery()

### DIFF
--- a/client/src/data-provider/Agents/queries.ts
+++ b/client/src/data-provider/Agents/queries.ts
@@ -104,8 +104,8 @@ export const useGetAgentByIdQuery = (
       refetchOnReconnect: false,
       refetchOnMount: false,
       retry: false,
-      enabled: isValidAgentId && (config?.enabled ?? true),
       ...config,
+      enabled: isValidAgentId && (config?.enabled ?? true),
     },
   );
 };


### PR DESCRIPTION
Otherwise, it's possible for a config to override the `isValidAgentId` check.

Without that check, it's possible to query `getAgentById()` with a blank `agent_id`, which can result in polluting the `QueryKeys.agent` cache with a full list of agents (instead of just a single agent result).

It turns out that, because of this mistake, our ModelInformationModal would cause that very pollution to happen, which would cause issues in the agent builder.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1867