### PR TITLE
make agent instructions required, and change helper text and placeholder

### DIFF
--- a/client/src/components/SidePanel/Agents/Instructions.tsx
+++ b/client/src/components/SidePanel/Agents/Instructions.tsx
@@ -4,6 +4,8 @@
 import React, { useState, useId } from 'react';
 import { PlusCircle } from 'lucide-react';
 import * as Menu from '@ariakit/react/menu';
+import { specialVariables } from 'librechat-data-provider';
+import { Controller, useFormContext } from 'react-hook-form';
 import {
   CircleHelpIcon,
   DropdownPopup,
@@ -13,13 +15,11 @@ import {
   HoverCardPortal,
   HoverCardTrigger,
 } from '@librechat/client';
-import { specialVariables } from 'librechat-data-provider';
-import { Controller, useFormContext } from 'react-hook-form';
 import type { TSpecialVarLabel } from 'librechat-data-provider';
 import type { AgentForm } from '~/common';
+import { njInputClass } from '~/nj/components/Agents/agentInputStyle';
 import { cn, defaultTextProps, removeFocusOutlines } from '~/utils';
 import { useLocalize } from '~/hooks';
-import { njInputClass } from '~/nj/components/Agents/agentInputStyle';
 
 const inputClass = cn(
   defaultTextProps,

--- a/client/src/components/SidePanel/Agents/Instructions.tsx
+++ b/client/src/components/SidePanel/Agents/Instructions.tsx
@@ -69,6 +69,7 @@ export default function Instructions() {
           htmlFor="instructions"
         >
           Give your agent a task
+          <span className="ml-1 text-red-500">*</span>
         </label>
         <HoverCard openDelay={50}>
           <HoverCardTrigger asChild>
@@ -80,9 +81,9 @@ export default function Instructions() {
             <HoverCardContent side={ESide.Top} className="w-80">
               <div className="space-y-2">
                 <p className="text-sm text-text-secondary">
-                  Try starting with a role (“You are a…”), then describe the task, any constraints,
-                  how you&apos;d like responses structured, and how the agent should use any
-                  uploaded files.
+                  Agents work best when they have a clearly defined identity and behavior. Define
+                  your agent&apos;s role, expertise, criteria for success, and how it should
+                  respond.
                 </p>
               </div>
             </HoverCardContent>
@@ -118,12 +119,14 @@ export default function Instructions() {
       <Controller
         name="instructions"
         control={control}
+        // NJ: We want agent instructions to be a required field
+        rules={{ required: true }}
         render={({ field, fieldState: { error } }) => (
           <>
             <textarea
               {...field}
               value={field.value ?? ''}
-              className={cn(njInputClass, 'min-h-[100px] resize-y')}
+              className={cn(njInputClass, 'min-h-[118px] resize-y')}
               id="instructions"
               placeholder={localize('com_agents_instructions_placeholder')}
               rows={3}
@@ -136,7 +139,9 @@ export default function Instructions() {
                 className="text-sm text-red-500 transition duration-300 ease-in-out"
                 role="alert"
               >
-                {localize('com_ui_field_required')}
+                {/* NJ: custom message for required agent
+                instructions field} */}
+                Add agent instructions before saving
               </span>
             )}
           </>

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -70,7 +70,7 @@
   "com_agents_file_search_disabled": "Agent must be created before uploading files for File Search.",
   "com_agents_file_search_info": "Once enabled, when you ask questions, the agent will search through your documents and reference specific details from them.",
   "com_agents_grid_announcement": "Showing {{count}} agents in {{category}} category",
-  "com_agents_instructions_placeholder": "The system instructions that the agent uses",
+  "com_agents_instructions_placeholder": "Minimum required: Begin with \"You are the [agent name], which helps to [agent's purpose].\" You can also add behavior, scope, and any rules it should follow.",
   "com_agents_link_copied": "Link copied",
   "com_agents_link_copy_failed": "Failed to copy link",
   "com_agents_load_more_label": "Load more agents from {{category}} category",


### PR DESCRIPTION
## Description
This PR makes the agent instructions required and changes the helper text and placeholder.

## Ticket
Refers to [Agent Instructions: Make Required and change helper text](https://github.com/newjersey/innovation-platform-pm/issues/1864)

## Steps to Test
1. Run the app locally.
2. Access the Agent Builder panel.
3. Scroll to the bottom of the panel.
4. Click the `Create` button.
5. Under **Instructions**, verify the following:
   - There is an asterisk (*) next to the text **Give your agent a task**
   - The placeholder text has been updated to **Minimum required: Begin with "You are the [agent name], which helps to [agent's purpose]." You can also add behavior, scope, and any rules it should follow.**
   - The tooltip text has been updated to **Agents work best when they have a clearly defined identity and behavior. Define your agent's role, expertise, criteria for success, and how it should respond.**
   - The error text **Add agent instructions before saving** is visible.
6. Add instructions and click `Save`.
7. Confirm that the success banner displays.

**After Implementation:**
<img width="236" height="239" alt="Screenshot 2026-06-24 at 2 43 30 PM" src="https://github.com/user-attachments/assets/de0019e2-cbaa-4383-a2a3-b18da6e16dad" />
<img width="275" height="314" alt="Screenshot 2026-06-24 at 2 43 17 PM" src="https://github.com/user-attachments/assets/b696319d-5f8b-4e91-b0c6-765d715407a6" />
