### PR TITLE
Created symlink from README-NJ.md -> .github/README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,1 @@
+../README-NJ.md


### PR DESCRIPTION
The hope is that this will show our README file by default in GitHub instead of the upstream's README.