### PR TITLE
Temporarily disable version history button

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentFooter.tsx
+++ b/client/src/components/SidePanel/Agents/AgentFooter.tsx
@@ -138,6 +138,7 @@ export default function AgentFooter({
       )}
 
       {/* Version history */}
+      {/* NJ: Temporarily turn this off for launch (it's having bugs). TODO: Fix bugs, turn on!
       {showButtons && agent_id && (
         <div data-testid="version-button">
           <NewJerseyPanelButton
@@ -151,6 +152,7 @@ export default function AgentFooter({
           <hr />
         </div>
       )}
+      */}
 
       {/* Admin settings (permissions & sharing) - we only let admins share agents atm */}
       {user?.role === SystemRoles.ADMIN && showButtons && (

--- a/client/src/components/SidePanel/Agents/__tests__/AgentFooter.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentFooter.spec.tsx
@@ -272,7 +272,7 @@ describe('AgentFooter', () => {
       render(<AgentFooter {...defaultProps} />);
       expect(screen.getByText('Save')).toBeInTheDocument();
       expect(screen.getByTestId('advanced-button')).toBeInTheDocument();
-      expect(screen.getByTestId('version-button')).toBeInTheDocument();
+      expect(screen.queryByTestId('version-button')).not.toBeInTheDocument();
       expect(screen.queryByTestId('delete-button')).not.toBeInTheDocument(); // NJ: Removed
       expect(screen.queryByTestId('admin-settings')).not.toBeInTheDocument();
       expect(screen.queryByTestId('grant-access-dialog-agent')).not.toBeInTheDocument(); // NJ: Removed


### PR DESCRIPTION
I considered simply deleting the code block, but since we're going to very quickly re-enable it I felt like leaving it around was better.

Part of https://github.com/newjersey/innovation-platform-pm/issues/1886