### PR TITLE
Make sure atoms are created only once

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentPanelSwitch.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanelSwitch.tsx
@@ -9,6 +9,8 @@ import ActionsPanel from './ActionsPanel';
 import AgentPanel from './AgentPanel';
 import store from '~/store';
 
+const showSplashPageState = atomWithLocalStorage('agentPanelSplashPage', true);
+
 export default function AgentPanelSwitch() {
   return (
     <AgentPanelProvider>
@@ -20,9 +22,7 @@ export default function AgentPanelSwitch() {
 function AgentPanelSwitchWithContext() {
   const { activePanel, setCurrentAgentId } = useAgentPanelContext();
   const agentId = useRecoilValue(store.conversationAgentIdByIndex(0));
-  const [showSplashPage, setShowSplashPage] = useRecoilState(
-    atomWithLocalStorage('agentPanelSplashPage', true),
-  );
+  const [showSplashPage, setShowSplashPage] = useRecoilState(showSplashPageState);
 
   useEffect(() => {
     const agent_id = agentId ?? '';

--- a/client/src/nj/components/SidePanel/Files/FilesPanel.tsx
+++ b/client/src/nj/components/SidePanel/Files/FilesPanel.tsx
@@ -16,6 +16,8 @@ import { atomWithLocalStorage } from '~/store/utils';
  * Hooks into functionality from parent built-in files panel via constructor params, but otherwise
  * is pretty much does everything else on its own.
  */
+const showSplashPageState = atomWithLocalStorage('filesPanelSplashPage', true);
+
 export default function FilesPanel({
   files,
   handleFileClick,
@@ -23,9 +25,7 @@ export default function FilesPanel({
   files: TFile[];
   handleFileClick: (file: TFile) => void;
 }) {
-  const [showSplashPage, setShowSplashPage] = useRecoilState(
-    atomWithLocalStorage('filesPanelSplashPage', true),
-  );
+  const [showSplashPage, setShowSplashPage] = useRecoilState(showSplashPageState);
   const [filenameFilter, setFilenameFilter] = useState('');
 
   const filteredFiles = filenameFilter

--- a/client/src/nj/components/TipComponent.tsx
+++ b/client/src/nj/components/TipComponent.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { X } from 'lucide-react';
-import { useRecoilState } from 'recoil';
 import uswdsIcons from '@uswds/uswds/img/sprite.svg';
-import { atomWithLocalStorage } from '~/store/utils';
+import { useLocalStorage } from '~/hooks';
 
 /**
  * Shows a small, dismissable tip.
@@ -20,9 +19,7 @@ export default function TipComponent({
   description: string;
   stateKey: string;
 }) {
-  const [showComplexBanner, setShowComplexBanner] = useRecoilState(
-    atomWithLocalStorage(stateKey, true),
-  );
+  const [showComplexBanner, setShowComplexBanner] = useLocalStorage(stateKey, true);
 
   if (!showComplexBanner) return null;
 


### PR DESCRIPTION
In Recoil, atoms must be created with a globally unique key. In the three files refactored in this PR, atoms were being created inside of React components, and so upon component rerender, Recoil would have duplicate atom key errors, like:
```
Expectation Violation: Duplicate atom key "agentPanelSplashPage". This is a FATAL ERROR in
      production. But it is safe to ignore this warning if it occurred because of
      hot module replacement.
    at atomWithLocalStorage (utils.ts:5:10)
    at AgentPanelSwitchWithContext (AgentPanelSwitch.tsx:24:5)
    ...
```
and
```
Expectation Violation: Duplicate atom key "showAgentComplexBanner". This is a FATAL ERROR in
      production. But it is safe to ignore this warning if it occurred because of
      hot module replacement.
    at atomWithLocalStorage (utils.ts:5:10)
    at TipComponent (TipComponent.tsx:24:5)
    ...
```

This PR should fix those issues:
1. In `AgentPanelSwitch` we extract the `atomWithLocalStorage` creation to the module context (this is a LibreChat component, but the splash page was added by us)
2. The same approach is taken in `FilesPanel`
3. The `TipComponent` was refactored to directly use the Local Storage hook since we cannot have a module-level `atom` (since the `stateKey` is a param of the component), but this was tested and works as expected