### PR TITLE
Fixup tiny things in metrics

### DIFF
--- a/nj/metrics/conversationsWithAgents.js
+++ b/nj/metrics/conversationsWithAgents.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 (function () {
-  const AGENTS_LAUNCH_DATE = ISODate('2026-06-25T00:00:00Z');
+  const AGENTS_LAUNCH_DATE = ISODate('2026-06-30T00:00:00Z');
   const total = db.conversations.countDocuments({ updatedAt: { $gte: AGENTS_LAUNCH_DATE } });
   const withAgent = db.conversations.countDocuments({
     updatedAt: { $gte: AGENTS_LAUNCH_DATE },

--- a/nj/metrics/platformAgentUsage.js
+++ b/nj/metrics/platformAgentUsage.js
@@ -20,7 +20,7 @@
         .aggregate([
           { $match: { agent_id: { $in: ids } } },
           { $group: { _id: '$agent_id', convs: { $sum: 1 }, users: { $addToSet: '$user' } } },
-          { $sort: { convs: -1 } },
+          { $sort: { _id: 1 } },
         ])
         .toArray()
         .map((d) => `${d._id},${nameById[d._id] ?? '?'},${d.convs},${d.users.length}`),


### PR DESCRIPTION
Update the Launch Date to the morning after Agents was launched, and give Platform Agent Conversation metrics a predictable sort order.