### PR TITLE
Add a feature flag to enable memory in Dev

### DIFF
--- a/.github/workflows/render-env.yml
+++ b/.github/workflows/render-env.yml
@@ -69,6 +69,7 @@ jobs:
           export GUARDRAIL_ID="${{ secrets.GUARDRAIL_ID }}"
           export GUARDRAIL_VERSION="${{ secrets.GUARDRAIL_VERSION }}"
 
+          export NJ_FF_MEMORY_ENABLED=$([[ "${{ inputs.environment }}" == "prod" ]] && echo false || echo true)
           export SEARCH=$([[ "${{ inputs.environment }}" == "prod" ]] && echo false || echo true)
           export MEILI_NO_ANALYTICS=true
           export MEILI_HOST=$([[ "${{ inputs.deploy_kitchensink }}" == "true" ]] && echo "http://meilisearch.kitchensink:7700" || echo "http://meilisearch.internal:7700")

--- a/nj/nj-librechat.yaml
+++ b/nj/nj-librechat.yaml
@@ -37,7 +37,7 @@ interface:
   fileSearch: true
   marketplace:
     use: true
-  memories: false
+  memories: true # Can be force-disabled with env var NJ_FF_MEMORY_ENABLED=false
   multiConvo: false
   parameters: false
   peoplePicker:
@@ -95,6 +95,14 @@ modelSpecs:
 
 ocr:
   strategy: 'document_parser'
+
+# Memory is enabled by default, disable it with `NJ_FF_MEMORY_ENABLED=false`
+memory:
+  tokenLimit: 2000
+  agent:
+    enabled: true
+    provider: 'bedrock'
+    model: 'us.anthropic.claude-sonnet-4-6'
 
 fileConfig:
   serverFileSizeLimit: 15 # Global multer limit (MB)

--- a/nj/nj.env.template
+++ b/nj/nj.env.template
@@ -146,3 +146,10 @@ HELP_AND_FAQ_URL=/
 # Google Analytics #
 #==================#
 ANALYTICS_GTM_ID=$ANALYTICS_GTM_ID
+
+#===============#
+# Feature Flags #
+#===============#
+
+# Enable/disable memory (true/false)
+NJ_FF_MEMORY_ENABLED=$NJ_FF_MEMORY_ENABLED

--- a/packages/data-schemas/src/app/service.ts
+++ b/packages/data-schemas/src/app/service.ts
@@ -119,6 +119,15 @@ export const AppService = async (params?: {
 
   const ocr = loadOCRConfig(config.ocr);
   const webSearch = loadWebSearchConfig(config.webSearch);
+
+  // NJ: Disable memory with the feature flag, `config.memory` gates the backend
+  // (`loadMemoryConfig` below) and frontend (`loadDefaultInterface` reads `config.memory` too).
+  if (getEnvBoolean('NJ_FF_MEMORY_ENABLED') === false) {
+    if (config.memory) {
+      config.memory.disabled = true;
+    } // else `config.memory` is undefined and therefore disabled
+  }
+
   const memory = loadMemoryConfig(config.memory);
   const summarization = loadSummarizationConfig(config);
   const skillSync = loadSkillSyncConfig(config);
@@ -226,3 +235,12 @@ export const AppService = async (params?: {
 
   return appConfig;
 };
+
+/**
+ * Helper for NJ feature flags.
+ */
+function getEnvBoolean(envVar: string): boolean | undefined {
+  const value = process.env[envVar];
+  if (value === undefined) return undefined;
+  return value.toLowerCase().trim() === 'true';
+}


### PR DESCRIPTION
This PR made me think it would be nice to templatize the `nj-librechat.yaml` file for features which are controlled via YAML, that may allow us to remove custom handling in `interface.ts` and now `service.ts` too, but that effort is out-of-scope for [this ticket](https://github.com/newjersey/innovation-platform-pm/issues/1810).

Here, I have enabled memory in the YAML and added a feature flag which will disable it in production. Testing disabled and enabled worked in local as expected:

<img width="342" height="90" alt="Screenshot 2026-07-09 at 9 28 50 PM" src="https://github.com/user-attachments/assets/87eed911-dd6a-49f4-be06-6a1e048d5e8f" />

<img width="1512" height="761" alt="Screenshot 2026-07-09 at 9 27 46 PM" src="https://github.com/user-attachments/assets/6cf2d020-443d-4c17-96b6-6d0b84de1d0b" />

<img width="1512" height="763" alt="Screenshot 2026-07-09 at 9 28 15 PM" src="https://github.com/user-attachments/assets/94425fbc-dd9b-4d19-8600-f8dab9ab430b" />

<img width="272" height="60" alt="Screenshot 2026-07-09 at 9 39 33 PM" src="https://github.com/user-attachments/assets/94d4cec0-14ed-4258-8330-05f93dc46f8a" />

<img width="1511" height="257" alt="Screenshot 2026-07-09 at 9 41 58 PM" src="https://github.com/user-attachments/assets/ddeed8ec-18c7-48b5-af68-da5af17c75e5" />

<img width="387" height="248" alt="Screenshot 2026-07-09 at 9 42 23 PM" src="https://github.com/user-attachments/assets/61643f1e-b8f9-4bbc-bec2-30161d27869b" />

<img width="1512" height="293" alt="Screenshot 2026-07-09 at 9 42 47 PM" src="https://github.com/user-attachments/assets/5f45a2e7-8b7c-4a80-b7d5-c1d96b684b43" />
