### PR TITLE
previous disablement of agent handoffs got lost in 6/10 upstream, disable since it is buggy

### DIFF
--- a/client/src/components/SidePanel/Agents/Advanced/OrchestrationHub.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/OrchestrationHub.tsx
@@ -46,12 +46,14 @@ export default function OrchestrationHub({ currentAgentId }: OrchestrationHubPro
             render={({ field }) => <AgentSubagents field={field} currentAgentId={currentAgentId} />}
           />
         )}
+        {/* NJ: Hiding AgentHandoffs, buggy atm
         <Controller
           name="edges"
           control={control}
           defaultValue={[]}
           render={({ field }) => <AgentHandoffs field={field} currentAgentId={currentAgentId} />}
         />
+        */}
         {chainEnabled && (
           <Controller
             name="agent_ids"


### PR DESCRIPTION
## Description
This PR reintroduces disabling agent handoffs.

## Ticket
Refer to [6/10 Upstream Merge Followup: Hide Agents HandOffs](https://github.com/newjersey/innovation-platform-pm/issues/1927)

