### PR TITLE
Re-add FileSearchCheckbox for the Agents File Search feature

### DIFF
--- a/client/src/nj/components/Agents/FileSearch.tsx
+++ b/client/src/nj/components/Agents/FileSearch.tsx
@@ -5,6 +5,7 @@ import React, { useMemo, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { AgentCapabilities, EModelEndpoint, EToolResources } from 'librechat-data-provider';
 import type { AgentForm, ExtendedFile } from '~/common';
+import FileSearchCheckbox from '~/nj/components/SidePanel/Agents/FileSearchCheckbox';
 import { useFileHandlingNoChatContext } from '~/hooks/Files/useFileHandling';
 import { useAgentFileConfig, useLazyEffect, useLocalize } from '~/hooks';
 import AddFilesButton from '~/nj/components/Agents/AddFilesButton';
@@ -76,6 +77,7 @@ export default function FileSearch({
           Upload any documents you want the agent to search through — like policy documents,
           research papers, and other work files.
         </p>
+        <FileSearchCheckbox />
       </div>
 
       {fileSearchChecked && (

--- a/client/src/nj/components/SidePanel/Agents/FileSearchCheckbox.tsx
+++ b/client/src/nj/components/SidePanel/Agents/FileSearchCheckbox.tsx
@@ -1,0 +1,72 @@
+/* eslint-disable i18next/no-literal-string */
+
+import { memo } from 'react';
+import { AgentCapabilities } from 'librechat-data-provider';
+import { useFormContext, Controller } from 'react-hook-form';
+import {
+  Checkbox,
+  HoverCard,
+  HoverCardContent,
+  HoverCardPortal,
+  HoverCardTrigger,
+  CircleHelpIcon,
+} from '@librechat/client';
+import type { AgentForm } from '~/common';
+import { ESide } from '~/common';
+
+function FileSearchCheckbox() {
+  const methods = useFormContext<AgentForm>();
+  const { control } = methods;
+
+  return (
+    <>
+      <HoverCard openDelay={50}>
+        <div className="my-2 flex items-center">
+          <Controller
+            name={AgentCapabilities.file_search}
+            control={control}
+            render={({ field }) => (
+              <Checkbox
+                {...field}
+                id="file-search-checkbox"
+                checked={field.value}
+                onCheckedChange={field.onChange}
+                className="relative float-left mr-2 inline-flex h-4 w-4 cursor-pointer"
+                value={field.value.toString()}
+                aria-labelledby="file-search-label"
+              />
+            )}
+          />
+          <label
+            id="file-search-label"
+            htmlFor="file-search-checkbox"
+            className="form-check-label text-token-text-primary cursor-pointer text-sm"
+          >
+            Enable File Search
+          </label>
+          <HoverCardTrigger asChild className="ml-2">
+            <button
+              type="button"
+              className="inline-flex items-center"
+              aria-label="When enabled, the agent will be informed of the exact filenames listed below, allowing it to retrieve relevant context from these files."
+            >
+              <CircleHelpIcon className="h-4 w-4 text-text-tertiary" />
+            </button>
+          </HoverCardTrigger>
+          <HoverCardPortal>
+            <HoverCardContent side={ESide.Top} className="w-80">
+              <div className="space-y-2">
+                <p className="text-sm text-text-secondary">
+                  When enabled, the agent will be informed of the exact filenames listed below,
+                  allowing it to retrieve relevant context from these files.
+                </p>
+              </div>
+            </HoverCardContent>
+          </HoverCardPortal>
+        </div>
+      </HoverCard>
+    </>
+  );
+}
+
+export default memo(FileSearchCheckbox);


### PR DESCRIPTION
The FileSearchCheckbox was removed upstream. Here, we are reinstating it on the NJ-side. I also opted to remove the translations and in-line them directly because one of the translations had already been removed upstream from the translation files.

As it turns out, adding this back also lets the File Search feature just work, so for now it seems that we don't have to worry about the fact that it was turned into a tool-add-on thing.

Ticket: https://github.com/newjersey/innovation-platform-pm/issues/1928