### PR TITLE
Various agent builder styling changes

### DIFF
--- a/client/src/components/SidePanel/Agents/Advanced/AdvancedPanel.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/AdvancedPanel.tsx
@@ -48,9 +48,7 @@ export default function AdvancedPanel() {
         >
           <ChevronLeft className="h-5 w-5" strokeWidth={1.75} aria-hidden="true" />
         </button>
-        <h2 className="text-center text-base font-semibold text-text-primary">
-          {localize('com_ui_advanced_settings')}
-        </h2>
+        <div className="mb-2 mt-2 text-xl font-medium">{localize('com_ui_advanced_settings')}</div>
         <span aria-hidden="true" className="h-10 w-10" />
       </header>
 

--- a/client/src/components/SidePanel/Agents/Advanced/AdvancedPanel.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/AdvancedPanel.tsx
@@ -40,11 +40,12 @@ export default function AdvancedPanel() {
   return (
     <div className="mb-1 flex w-full flex-col gap-4 text-sm">
       <header className="grid grid-cols-[auto_1fr_auto] items-center gap-2 pt-1">
+        {/* NJ: Use custom styling */}
         <button
           type="button"
           onClick={() => setActivePanel(Panel.builder)}
           aria-label={localize('com_ui_back_to_builder')}
-          className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl border border-border-light text-text-secondary transition-colors hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary"
+          className="btn btn-neutral relative"
         >
           <ChevronLeft className="h-5 w-5" strokeWidth={1.75} aria-hidden="true" />
         </button>

--- a/client/src/components/SidePanel/Agents/Advanced/MaxAgentSteps.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/MaxAgentSteps.tsx
@@ -13,7 +13,7 @@ export default function MaxAgentSteps() {
     <HoverCard openDelay={50}>
       <div className="flex flex-col gap-1.5">
         <div className="flex items-center gap-1.5">
-          <label htmlFor="recursion_limit" className="text-[13px] font-medium text-text-primary">
+          <label htmlFor="recursion_limit" className="text-[13px] font-semibold text-text-primary">
             {localize('com_ui_agent_recursion_limit')}
           </label>
           <InfoTrigger />

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -26,7 +26,7 @@ import store from '~/store';
 
 const fieldClass = 'h-9';
 const sectionLabelClass = 'font-semibold';
-const labelClass = 'mb-2 text-token-text-primary block text-sm font-medium';
+const labelClass = 'mb-2 text-token-text-primary block text-sm font-semibold';
 
 export default function AgentConfig() {
   const localize = useLocalize();
@@ -138,7 +138,7 @@ export default function AgentConfig() {
               className={njInputClass}
               id="description"
               type="text"
-              placeholder={localize('com_agents_description_placeholder')}
+              placeholder="Optional: Describe your Agent here"
               aria-label="Agent description"
             />
           )}


### PR DESCRIPTION
Ticket: [6/10 Merge Followup: Agent Builder Styling Changes](https://github.com/newjersey/innovation-platform-pm/issues/1932)

- Changed font weight on "Agents Name" input label.

- Changed "Description" placeholder text.

- Changed "Advanced Panel" header to div and updated styling.

- Changed "Max Agent Steps" font weight.

- Update styling on "Back to Builder" button