### PR TITLE
spike: prototype global system prompt implementation

### DIFF
--- a/nj/nj-librechat.yaml
+++ b/nj/nj-librechat.yaml
@@ -44,8 +44,10 @@ interface:
     users: false
     groups: false
     roles: false
-  presets: false
-  prompts: false
+  # presets: false
+  presets: true
+  # prompts: false
+  prompts: true
   runCode: false
   sidePanel: false
   webSearch: false
@@ -92,7 +94,6 @@ modelSpecs:
       preset:
         endpoint: 'bedrock'
         model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
-
 ocr:
   strategy: 'document_parser'
 

--- a/packages/api/src/agents/context.ts
+++ b/packages/api/src/agents/context.ts
@@ -96,13 +96,15 @@ export async function getMCPInstructionsForServers(
  * @returns {string | undefined} Combined instructions, or undefined if empty
  */
 export function buildAgentInstructions({
+  globalSystemPrompt,
   baseInstructions,
   mcpInstructions,
 }: {
+  globalSystemPrompt?: string;
   baseInstructions?: string;
   mcpInstructions?: string;
 }): string | undefined {
-  const parts = [baseInstructions, mcpInstructions].filter(Boolean);
+  const parts = [globalSystemPrompt, baseInstructions, mcpInstructions].filter(Boolean);
   const combined = parts.join('\n\n').trim();
   return combined || undefined;
 }
@@ -136,6 +138,8 @@ export function buildAgentAdditionalInstructions({
  * @param {Logger} [params.logger] - Optional logger instance
  * @returns {Promise<void>}
  */
+
+console.log('applyContextToAgent called');
 export async function applyContextToAgent({
   agent,
   sharedRunContext,
@@ -153,6 +157,12 @@ export async function applyContextToAgent({
   logger?: Logger;
   configServers?: Record<string, ParsedServerConfig>;
 }): Promise<void> {
+  const globalSystemPrompt = `You are an AI assistant built for our organization's employees. 
+    You are an advanced language model, NOT a human. 
+    When referring to yourself, do not use first-person pronouns.
+    Refer to yourself as "the NJ AI Assistant" or "NJ AIA" or "AIA".
+    Do not use first-person human phrasing like "I am feeling good today" or "As a person...". 
+    Always maintain an objective, helpful, and clearly non-human persona.`;
   const baseInstructions = agent.instructions || '';
   const additionalInstructions = agent.additional_instructions || '';
 
@@ -164,8 +174,10 @@ export async function applyContextToAgent({
       logger,
       configServers,
     );
+    console.log('before buildAgentInstructions');
 
     agent.instructions = buildAgentInstructions({
+      globalSystemPrompt,
       baseInstructions,
       mcpInstructions,
     });
@@ -174,11 +186,15 @@ export async function applyContextToAgent({
       sharedRunContext,
     });
 
+    logger?.debug('{AgentContext] Final agent instructions', agent.instructions);
+    console.log('Logging final agent instructions', agent.instructions);
+
     if (agentId && logger) {
       logger.debug(`[AgentContext] Applied context to agent: ${agentId}`);
     }
   } catch (error) {
     agent.instructions = buildAgentInstructions({
+      globalSystemPrompt,
       baseInstructions,
       mcpInstructions: '',
     });


### PR DESCRIPTION
## Description
This spike validates whether a backend-controlled approach exists for applying a global system prompt to Agent conversations. We did not use `promptPrefix` because it is scoped to standard chat conversations and does not provide a global prompt layer for Agents.

## Ticket
Refers to [[spike] System Prompt - Research Spike](https://github.com/newjersey/innovation-platform-pm/issues/1809)

## Approach
To address the `promptPrefix` implementation not affecting Agents, the following changes were made:
- Added a temporary hard-coded `globalSystemPrompt` in `applyContextToAgent()`.
- Updated `buildAgentInstructions()` to prepend the global system prompt before the Agent’s base instructions and MCP instructions.
- Applied the same behavior in the fallback (`catch`) path.

The instruction sequence used during implementation:
1. Global system prompt
2. Agent base instructions
3. MCP instructions

## Findings
Behavioral testing confirmed that a shared backend-controlled prompt can be prepended to Agent instructions while preserving existing Agent behavior.

## Notes
- The global system prompt is intentionally hard-coded for prototyping and is **not** intended to be the final implementation.
- Any temporary debugging or test code should be removed before a production implementation.
- Existing tests are failing because they don't account for the global system prompt introduced by this prototype.