### PR TITLE
adjust context meter styling to match NJ AI Assistant color theme

### DIFF
--- a/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
+++ b/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
@@ -14,10 +14,11 @@ function Row({ label, value, max }: RowProps) {
   return (
     <div className="flex items-center justify-between gap-4 text-sm">
       <span className="text-text-secondary">{label}</span>
-      <span className="font-medium text-text-primary">
+      {/* NJ: custom styling*/}
+      <span className="text-text-primary">
         {formatTokens(value)}
         {percent != null && (
-          <span className="ml-1 text-xs text-text-secondary" aria-hidden="true">
+          <span className="ml-1 text-sm text-text-primary" aria-hidden="true">
             ({Math.round(percent)}%)
           </span>
         )}
@@ -73,10 +74,12 @@ export default function Breakdown({ view, showCost, currency }: BreakdownProps) 
   return (
     <div className="w-64 space-y-3" role="region" aria-label={localize('com_ui_context_usage')}>
       <div className="flex items-center justify-between">
-        <span className="text-sm font-medium text-text-primary">
+        {/* NJ: custom styling - font weight*/}
+        <span className="text-sm font-semibold text-text-primary">
           {localize('com_ui_context_window')}
         </span>
-        <span className="text-xs font-medium text-text-secondary">
+        {/* NJ: custom styling*/}
+        <span className="text-sm text-text-primary">
           {maxTokens != null
             ? `${formatTokens(usedTokens)} / ${formatTokens(maxTokens)} (${Math.round(percent)}%)`
             : formatTokens(usedTokens)}


### PR DESCRIPTION
## Description
This PR adjusts the context meter styling to match NJ AI Assistant color theme.

## Ticket 
Refers to [Update context meter](https://github.com/newjersey/innovation-platform-pm/issues/1937).
A PR to contribute upstream: [chore: add label for token usage totals to context meter]