### PR TITLE
hide keyboard shortcuts since we don't allow certain features that one could short cut to

### DIFF
--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -43,7 +43,10 @@ function KeyboardShortcutsProvider() {
   useKeyboardShortcuts();
   return (
     <>
+      {/* NJ: Hiding keyboard shortcuts; it allows functioanlity 
+      we don't allow (e.g. delete conversation)
       <KeyboardShortcutsDialog />
+     */}
       <KeyboardDeleteDialog />
     </>
   );


### PR DESCRIPTION
## Description
There are some keyboard shortcuts (e.g. deleting a conversation) that users cannot perform in the application. This PR hides the keyboard shortcuts so we don't show users actions they can't perform.

## Ticket
Refers to [Remove keyboard shortcuts](https://github.com/newjersey/innovation-platform-pm/issues/1948)

## Steps to Test
1. Run the app locally.
2.  On the landing page, press `command` + `shift` + `/`.
3. Confirm that the keyboard shortcuts dialog does not appear.
4. Repeat Step 2 on the kitchensink.
5. Confirm the keyboard shortcuts dialog does appear.