### PR TITLE
Add a splash page for Memories, rework the 'Use memory' toggle button

### DIFF
--- a/client/src/components/SidePanel/Memories/MemoryPanel.tsx
+++ b/client/src/components/SidePanel/Memories/MemoryPanel.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState, useEffect } from 'react';
-import { Plus } from 'lucide-react';
+import { useRecoilState } from 'recoil';
+import { Plus, Check } from 'lucide-react';
 import { matchSorter } from 'match-sorter';
 import { SystemRoles, PermissionTypes, Permissions } from 'librechat-data-provider';
 import {
   Button,
-  Checkbox,
   Spinner,
   Dropdown,
   FilterInput,
@@ -18,13 +18,19 @@ import {
   useMemoriesQuery,
   useGetUserQuery,
 } from '~/data-provider';
+import MemoryPanelSplash from '~/nj/components/SidePanel/Memories/MemoryPanelSplash';
 import { useLocalize, useAuthContext, useHasAccess } from '~/hooks';
 import MemoryCreateDialog from './MemoryCreateDialog';
+import { atomWithLocalStorage } from '~/store/utils';
 import MemoryUsageBadge from './MemoryUsageBadge';
 import AdminSettings from './AdminSettings';
 import MemoryList from './MemoryList';
+import { cn } from '~/utils';
 
 const pageSize = 10;
+
+// NJ: Show a one-time splash page introducing memories on first visit
+const showSplashPageState = atomWithLocalStorage('memoryPanelSplashPage', true);
 
 /** Partition filter sentinels; any other value is an agent id */
 const PARTITION_ALL = 'all';
@@ -41,6 +47,7 @@ export default function MemoryPanel() {
   const [partitionFilter, setPartitionFilter] = useState(PARTITION_ALL);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [referenceSavedMemories, setReferenceSavedMemories] = useState(true);
+  const [showSplashPage, setShowSplashPage] = useRecoilState(showSplashPageState);
 
   const updateMemoryPreferencesMutation = useUpdateMemoryPreferencesMutation({
     onSuccess: () => {
@@ -143,6 +150,11 @@ export default function MemoryPanel() {
     setPageIndex(0);
   }, [searchQuery, activePartition]);
 
+  // NJ: Show a splash page the first time a user accesses memories
+  if (showSplashPage) {
+    return <MemoryPanelSplash setShowSplashPage={setShowSplashPage} />;
+  }
+
   if (isLoading) {
     return (
       <div className="flex h-full w-full items-center justify-center p-4">
@@ -224,24 +236,34 @@ export default function MemoryPanel() {
 
             {/* Memory Toggle */}
             {hasOptOutAccess && (
-              <Button
-                size="sm"
-                variant="outline"
-                className={`ml-auto ${referenceSavedMemories ? 'bg-surface-hover hover:bg-surface-hover' : ''}`}
+              // NJ: Customize the memory toggle
+              <button
+                type="button"
+                className={cn(
+                  'btn !rounded-lg text-text-primary ring-offset-background focus-visible:ring-2',
+                  'ml-auto gap-2 !transition-none focus-visible:ring-ring focus-visible:ring-offset-2',
+                  referenceSavedMemories ? 'bg-surface-tertiary' : '!border-border-medium',
+                )}
                 onClick={() => handleMemoryToggle(!referenceSavedMemories)}
                 aria-label={localize('com_ui_use_memory')}
                 aria-pressed={referenceSavedMemories}
                 disabled={updateMemoryPreferencesMutation.isLoading}
               >
-                <Checkbox
-                  checked={referenceSavedMemories}
-                  tabIndex={-1}
+                <span
                   aria-hidden="true"
-                  aria-label={localize('com_ui_use_memory')}
-                  className="pointer-events-none mr-2"
-                />
+                  className={cn(
+                    'flex size-4 shrink-0 items-center justify-center rounded-[2px] border',
+                    referenceSavedMemories
+                      ? 'border-transparent bg-primary text-primary-foreground'
+                      : 'border-border-xheavy bg-transparent',
+                  )}
+                >
+                  {referenceSavedMemories && (
+                    <Check className="size-3" strokeWidth={3} aria-hidden="true" />
+                  )}
+                </span>
                 {localize('com_ui_use_memory')}
-              </Button>
+              </button>
             )}
           </div>
         )}

--- a/client/src/nj/components/SidePanel/Memories/MemoryPanelSplash.tsx
+++ b/client/src/nj/components/SidePanel/Memories/MemoryPanelSplash.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable i18next/no-literal-string */
+/* ^ We're not worried about i18n for this app ^ */
+
+import { Link } from 'react-router-dom';
+import type { SetterOrUpdater } from 'recoil';
+
+/**
+ * Splash page that introduces the memories feature to users.
+ */
+export default function MemoryPanelSplash({
+  setShowSplashPage,
+}: {
+  setShowSplashPage: SetterOrUpdater<boolean>;
+}) {
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <div className="flex min-h-full flex-col">
+        {/* Adds top spacing */}
+        <div className="flex-1" />
+
+        {/* Splash info */}
+        <div className="flex flex-col gap-4 p-1">
+          <h1 className="text-xl font-bold">User memories</h1>
+
+          <p className="text-md text-text-primary">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+            dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+            mollit anim id est laborum.
+          </p>
+
+          <Link
+            to="nj/release-notes"
+            className="text-md font-semibold text-jersey-button underline hover:decoration-2"
+          >
+            Read the release notes
+          </Link>
+
+          <button
+            onClick={() => setShowSplashPage(false)}
+            className="text-md w-full rounded bg-jersey-button py-3 font-semibold text-white hover:bg-jersey-button-hover"
+          >
+            View your memories
+          </button>
+        </div>
+
+        {/* Adds bottom spacing */}
+        <div className="flex-[2]" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add a splash page for Memories just like other features like the Agent Builder and the Files side-panel. As well, rework the 'Use memory' toggle to match what Design wants. The splash page is currently a placeholder with Lorem Ipsum text. The toggle button did take a fair amount of work though:
- Replaced the Button and Checkbox components with a plain button tag and a checkbox span (previously, the checkbox was apparently a button itself, and nested buttons is invalid HTML)
- Added the `btn` class, but couldn't use one of the `btn-*` classes as the styles seemed too wildly different, which left the button with some buggy design
- Fixed the focus-flicker (focus outline appeared and then disappeared) by overriding btn's "transition-all" class
- Set a standard dark focus ring
- Fixed up radii and spacing
- used !important as needed to override

Toggle button:
| Before | After |
|---|---|
| <img width="132" src="https://github.com/user-attachments/assets/7f3efc0f-4ac1-472d-8a93-d51e69f50cdb" /> | <img width="127" src="https://github.com/user-attachments/assets/03daa33a-07b1-452f-968e-e6deb090a7fa" /> |
| <img width="133" src="https://github.com/user-attachments/assets/e91c742a-490f-45f3-b085-8cebdfdd40e8" /> | <img width="125" src="https://github.com/user-attachments/assets/ce1a251d-680d-4d95-b0b0-5e34d75218c8" /> |

Ticket: https://github.com/newjersey/innovation-platform-pm/issues/1941