### PR TITLE
update context meter background color and border

### DIFF
--- a/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
+++ b/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
@@ -183,6 +183,9 @@ export default function Breakdown({ view, showCost, currency }: BreakdownProps) 
         <>
           <div className="border-t border-border-light" role="separator" />
           <div className="space-y-1.5" data-testid="token-usage-totals">
+            <span className="text-sm font-semibold text-text-primary">
+              {localize('com_ui_last_prompt_and_reply')}
+            </span>
             <Row label={localize('com_ui_input')} value={branchUsage.input} />
             <Row label={localize('com_ui_output')} value={branchUsage.output} />
             {branchUsage.cacheRead > 0 && (

--- a/client/src/components/Chat/Input/TokenUsage/index.tsx
+++ b/client/src/components/Chat/Input/TokenUsage/index.tsx
@@ -102,7 +102,7 @@ function TokenUsageIndicator({
         unmountOnHide
         finalFocus={disclosureRef}
         aria-label={localize('com_ui_context_usage')}
-        className="z-[200] rounded-xl border border-border-medium bg-surface-secondary p-3 shadow-lg focus:outline-none"
+        className="z-[200] rounded-xl border border-[var(--border-warm-gray-12)] bg-surface-primary-alt p-3 shadow-lg focus:outline-none"
       >
         <Breakdown view={view} showCost={showCost} currency={currency} />
       </Ariakit.Popover>

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1304,6 +1304,7 @@
   "com_ui_key": "Key",
   "com_ui_key_required": "API key is required",
   "com_ui_labels": "Labels",
+  "com_ui_last_prompt_and_reply": "Last prompt and reply",
   "com_ui_late_night": "Happy late night",
   "com_ui_latest": "latest",
   "com_ui_latest_activity": "Latest activity",

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -172,6 +172,7 @@ html {
   --surface-destructive-hover: var(--red-800);
   --surface-chat: #ffffff; /* Custom for NJ */
   --border-light: #efedec; /* Custom for NJ, #332015 @ .08 opacity */
+  --border-warm-gray-12: #3320151f; /* Custom for NJ with .12 opacity */
   --border-medium-alt: var(--gray-300);
   --border-medium: var(--gray-300);
   --border-heavy: var(--gray-400);


### PR DESCRIPTION
## Description
This PR adds a label for token usage totals to the context meter to improve clarity of token usage information (in place of waiting for upstream contribution to be accepted). It also updates context meter background color and border styling.
 

## Ticket 
Part of [Update context meter](https://github.com/newjersey/innovation-platform-pm/issues/1937)
