### PR TITLE
Update KitchenSink rag-api jwt-secret location to avoid colliding with Dev

### DIFF
--- a/nj/infra/bin/cdk.ts
+++ b/nj/infra/bin/cdk.ts
@@ -163,7 +163,7 @@ if (process.env.DEPLOY_KITCHENSINK === 'true') {
     listenerArn: ecsStack.listener.listenerArn,
     certificateArn: `arn:aws:acm:${env.region}:${env.account}:certificate/${process.env.LIBRECHAT_ACM_CERTIFICATE_ID}`,
     mongoSecretArn: `arn:aws:secretsmanager:${env.region}:${env.account}:secret:ai-assistant/kitchensink/mongodb-B2athN`,
-    ragApiJwtSecretArn: `arn:aws:secretsmanager:${env.region}:${env.account}:secret:ai-assistant/rag-api/jwt-secret-${ragApiJwtSecretSuffix[AWS_ENV]}`,
+    ragApiJwtSecretArn: `arn:aws:secretsmanager:${env.region}:${env.account}:secret:ai-assistant/kitchensink/rag-api-jwt-secret`,
   });
 
   applyTags(kitchenSinkStack);


### PR DESCRIPTION
As it stands, KitchenSink and Dev are pulling the same rag-api JWT_SECRET value, but the environments configure different values in LibreChat. This PR should update the KitchenSink stack to pull a different Secrets Manager secret and thus allow the environments to have different values.