### PR TITLE
disable keyboard shortcut functionality

### DIFF
--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -40,16 +40,16 @@ declare global {
 
 /** Isolates keyboard shortcut listeners so they only mount after auth. */
 function KeyboardShortcutsProvider() {
-  /* NJ: Hides keyboard shortcuts; they enable unsupported functionality (e.g. deleting chats). */
+  /* NJ: return early to disable keyboard shortcuts, which allow unsupported functionality (e.g. deleting chats). */
   return null;
 
-  // useKeyboardShortcuts();
-  // return (
-  //   <>
-  //     <KeyboardShortcutsDialog />
-  //     <KeyboardDeleteDialog />
-  //   </>
-  // );
+  useKeyboardShortcuts();
+  return (
+    <>
+      <KeyboardShortcutsDialog />
+      <KeyboardDeleteDialog />
+    </>
+  );
 }
 
 export default function Root() {

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -40,16 +40,16 @@ declare global {
 
 /** Isolates keyboard shortcut listeners so they only mount after auth. */
 function KeyboardShortcutsProvider() {
-  useKeyboardShortcuts();
-  return (
-    <>
-      {/* NJ: Hiding keyboard shortcuts; it allows functioanlity 
-      we don't allow (e.g. delete conversation)
-      <KeyboardShortcutsDialog />
-     */}
-      <KeyboardDeleteDialog />
-    </>
-  );
+  /* NJ: Hides keyboard shortcuts; they enable unsupported functionality (e.g. deleting chats). */
+  return null;
+
+  // useKeyboardShortcuts();
+  // return (
+  //   <>
+  //     <KeyboardShortcutsDialog />
+  //     <KeyboardDeleteDialog />
+  //   </>
+  // );
 }
 
 export default function Root() {


### PR DESCRIPTION
## Description

We do not allow users to delete chats, so this PR disables the delete chat keyboard shortcut.

## Ticket
Part of [Remove keyboard shortcuts](https://github.com/newjersey/innovation-platform-pm/issues/1948)

## Steps to Test
1. Run the app locally.
2.  Navigate to an existing conversation.
3. Press `command` + `shift` + `delete`.
4. Confirm that the delete chat modal does not appear.
5. Repeat Step 2 on the kitchensink.
6. Confirm that the delete chat modal does appear.

**Delete Chat Modal (accessed via keyboard shortcut):**
<img width="374" height="198" alt="Screenshot 2026-07-22 at 11 49 13 AM" src="https://github.com/user-attachments/assets/4e212819-cded-407a-af4f-5efb29a42d19" />

