### PR TITLE
Replace custom model seleciton filtering with showInMenu toggle

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -93,9 +93,7 @@ export function renderModelSpecs(specs: TModelSpec[], selectedSpec: string) {
     return null;
   }
 
-  return specs
-    .filter((spec) => spec.default) // NJ: Only render default model spec (for now)
-    .map((spec) => (
-      <ModelSpecItem key={spec.name} spec={spec} isSelected={selectedSpec === spec.name} />
-    ));
+  return specs.map((spec) => (
+    <ModelSpecItem key={spec.name} spec={spec} isSelected={selectedSpec === spec.name} />
+  ));
 }

--- a/client/src/hooks/Input/useMentions.ts
+++ b/client/src/hooks/Input/useMentions.ts
@@ -165,10 +165,6 @@ export default function useMentions({
       if (spec.preset?.endpoint === EModelEndpoint.agents && spec.preset?.agent_id) {
         return spec.preset.agent_id in agentsMap;
       }
-      // NJ: Only render default model spec (for now)
-      if (!spec.default) {
-        return false;
-      }
       /** Keep non-agent modelSpecs */
       return true;
     });

--- a/nj/librechat-config/librechat.dev.yaml
+++ b/nj/librechat-config/librechat.dev.yaml
@@ -24,8 +24,7 @@ interface:
   # Disable temporary chats (we need to retain data for OPRA)
   temporaryChat: false
 
-  # We allow model selection in general, but in the code we filter to only
-  # models that we want to allow users to see
+  # We allow model selection in general, but set `showInMenu: false` to hide a model-spec
   modelSelect: true
 
   # We're purposefully disabling most LibreChat features (for now)
@@ -86,6 +85,7 @@ modelSpecs:
   list:
     - name: claude-sonnet-4-6
       label: 'Claude Sonnet 4.6'
+      showInMenu: false
       preset:
         endpoint: 'bedrock'
         model: 'us.anthropic.claude-sonnet-4-6'

--- a/nj/librechat-config/librechat.kitchensink.yaml
+++ b/nj/librechat-config/librechat.kitchensink.yaml
@@ -97,7 +97,6 @@ modelSpecs:
         model: 'us.anthropic.claude-sonnet-4-6'
     - name: 'Claude Sonnet 4.5'
       label: 'Claude Sonnet 4.5'
-      default: true
       preset:
         endpoint: 'bedrock'
         model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'

--- a/nj/librechat-config/librechat.prod.yaml
+++ b/nj/librechat-config/librechat.prod.yaml
@@ -24,8 +24,7 @@ interface:
   # Disable temporary chats (we need to retain data for OPRA)
   temporaryChat: false
 
-  # We allow model selection in general, but in the code we filter to only
-  # models that we want to allow users to see
+  # We allow model selection in general, but set `showInMenu: false` to hide a model-spec
   modelSelect: true
 
   # We're purposefully disabling most LibreChat features (for now)
@@ -86,6 +85,7 @@ modelSpecs:
   list:
     - name: claude-sonnet-4-6
       label: 'Claude Sonnet 4.6'
+      showInMenu: false
       preset:
         endpoint: 'bedrock'
         model: 'us.anthropic.claude-sonnet-4-6'

--- a/nj/librechat-config/librechat.yaml.njk
+++ b/nj/librechat-config/librechat.yaml.njk
@@ -21,8 +21,7 @@ interface:
   # Disable temporary chats (we need to retain data for OPRA)
   temporaryChat: false
 
-  # We allow model selection in general, but in the code we filter to only
-  # models that we want to allow users to see
+  # We allow model selection in general, but set `showInMenu: false` to hide a model-spec
   modelSelect: true
 
   # We're purposefully disabling most LibreChat features (for now)
@@ -87,6 +86,7 @@ modelSpecs:
   list:
     - name: claude-sonnet-4-6
       label: 'Claude Sonnet 4.6'
+      showInMenu: false
       preset:
         endpoint: 'bedrock'
         model: 'us.anthropic.claude-sonnet-4-6'


### PR DESCRIPTION
Previously, customizations were made in `ModelSpecItem.tsx` and `useMentions.ts` to ensure only a `default: true` model appeared in the model-selection dropdown as well as the "@" options menu. But it seems like this can be replaced with a built-in Model Spec toggle: `showInMenu`.

The support landed upstream only on [June 30th](https://github.com/danny-avila/LibreChat/pull/14034), so it is a very new feature which does exactly what we want.

**Before** has the custom filtering removed, but doesn't have `showInMenu: false`. **After** does use `showInMenu: false`. 
| Before | After |
| --- | --- |
| <img width="502" src="https://github.com/user-attachments/assets/20acade2-4a0d-4cbf-b846-654cb42f7af2" /> | <img width="502" src="https://github.com/user-attachments/assets/3c2990c1-1eed-443f-a4ef-133ac16aed3f" /> |
| <img width="502" src="https://github.com/user-attachments/assets/5407685a-0ee5-42dd-bff6-fa85276d7f7c" /> | <img width="501" src="https://github.com/user-attachments/assets/e0f1a262-1b28-4c6b-85f4-e7d134b55c6d" /> |

