### PR TITLE
Fixup typechecks in nj/

### DIFF
--- a/.github/workflows/nj-infra-review.yml
+++ b/.github/workflows/nj-infra-review.yml
@@ -1,10 +1,8 @@
-name: NJ Config Tests
+name: NJ Infra Tests
 on:
   pull_request:
     paths:
-      - 'nj/librechat-config/**'
-      - '.env.nj-dev'
-      - '.env.nj-prod'
+      - 'nj/infra/**'
 
 permissions:
   contents: read
@@ -14,13 +12,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-config:
-    name: Check librechat.yaml files for drift + schema validation
+  typecheck-infra:
+    name: TypeScript type checks (nj-infra)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
       run:
-        working-directory: nj/librechat-config
+        working-directory: nj/infra
     steps:
       - uses: actions/checkout@v7
 
@@ -32,5 +30,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run drift + schema tests
-        run: npm test
+      - name: Type check infra
+        run: npm run typecheck

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -24,17 +24,10 @@
     }
   },
   "types": ["node", "jest", "@testing-library/jest-dom"],
-  "exclude": [
-    "node_modules",
-    "vite.config.ts",
-    "../nj/e2e/**/*",
-    "../nj/infra/**/*",
-    "../nj/lambda/**/*"
-  ],
+  "exclude": ["node_modules", "vite.config.ts"],
   "include": [
     "src/**/*",
     "test/**/*",
-    "../nj/**/*",
     "test/setupTests.js",
     "env.d.ts",
     "../packages/client/src/hooks/useDelayedRender.tsx",

--- a/nj/infra/package.json
+++ b/nj/infra/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "watch": "tsc -w",
     "synth": "npx cdk synth",
     "deploy": "npx cdk deploy",

--- a/nj/librechat-config/package.json
+++ b/nj/librechat-config/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "tsc && jest",
     "nj-render-configs": "tsc && node dist/render.js",
     "nj-render-local-config": "tsc && node dist/render.js --local"


### PR DESCRIPTION
In commit 0c4a4f0e, a change was made which would include the `nj/` directory on `client/` typechecks. This was a bit problematic though, for example typechecking the `nj/librechat-config/` files would fail simply because the the `client` workspace can't typecheck unshared dependencies of the `librechat-config` workspace.

This PR removes the coupling between `client/` and the `nj/` directory altogether. It also adds typechecking commands and a PR workflow to ensure types are happy at least in some parts of the `nj/` directory.